### PR TITLE
Update NuGet packages and merge main branch

### DIFF
--- a/src/Chargeback.AppHost/Chargeback.AppHost.csproj
+++ b/src/Chargeback.AppHost/Chargeback.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.1">
 
   <ItemGroup>
     <ProjectReference Include="..\Chargeback.Api\Chargeback.Api.csproj" />

--- a/src/Chargeback.Benchmarks/Properties/launchSettings.json
+++ b/src/Chargeback.Benchmarks/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Chargeback.Benchmarks": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:52043;http://localhost:52044"
+    }
+  }
+}

--- a/src/Chargeback.LoadTest/Chargeback.LoadTest.csproj
+++ b/src/Chargeback.LoadTest/Chargeback.LoadTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" VersionOverride="9.0.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="NBomber" />
     <PackageReference Include="NBomber.Http" />
   </ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,30 +4,30 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="13.2.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.CosmosDB" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="13.2.1" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.1" />
 
     <!-- Azure -->
-    <PackageVersion Include="Azure.Identity" Version="1.19.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
 
     <!-- Microsoft -->
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0-rc2" />
-    <PackageVersion Include="Microsoft.Agents.AI.Purview" Version="1.0.0-rc4" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Purview" Version="1.0.0-rc6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.82.1" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
 
     <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />


### PR DESCRIPTION
This pull request primarily updates dependencies across the solution to newer versions, improving security, compatibility, and access to new features. It also introduces a launch profile for the benchmarks project and removes a version override to simplify package management.

**Dependency Updates:**

* Updated Aspire-related NuGet packages to version `13.2.1` in both `Directory.Packages.props` and the `Chargeback.AppHost` project file for consistency and to take advantage of the latest features and fixes. [[1]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L7-R30) [[2]](diffhunk://#diff-ea45cf2bcc05cf0540e661fd99a9988ab5c29701988bffe8e4fee48c870599c3L1-R1)
* Upgraded several other dependencies, including `Azure.Identity`, `Microsoft.Agents.AI`, `Microsoft.Agents.AI.Purview`, `Microsoft.Identity.Web`, `Microsoft.NET.Test.Sdk`, and `OpenTelemetry` packages to their latest versions.

**Project Configuration:**

* Added a `launchSettings.json` file to the `Chargeback.Benchmarks` project, enabling easier local development and debugging with predefined URLs and environment variables.
* Removed the `VersionOverride` attribute from the `Microsoft.Extensions.Configuration` package reference in `Chargeback.LoadTest.csproj` to use the default version specified in the central package management.