### PR TITLE
feat: APIM policy management, access profile blocking, Keycloak auth & SAST fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,12 @@ All decisions are cached in Redis for sub-millisecond latency; all configuration
 ## Key Features
 
 ### 🔐 Authentication & Authorization at the Gate
+- **Dual identity provider support**: Switch between Entra ID (Azure AD) and Keycloak via a single `AuthProvider` config toggle
 - Entra ID JWT bearer tokens with multi-tenant support
+- Keycloak OIDC with client_credentials flow for APIM service-to-service calls
 - Pre-check endpoint validates client, plan, deployment access, and quotas BEFORE backend receives the request
 - No subscription keys — pure identity-driven access control
+- Runtime auth config endpoint (`/api/auth-config`) — one container image works across all environments
 
 ### 🚀 Intelligent Model Routing (Auto-Router)
 - Automatically routes requests to optimal deployments based on plan routing policies
@@ -238,6 +241,10 @@ The React SPA provides five pages:
 
 ## Authentication
 
+The AI Policy Engine supports two identity providers, selected at runtime via the `AuthProvider` configuration value (`AzureAd` or `Keycloak`). The same container image works for both — no rebuild required.
+
+### Entra ID (Azure AD) — Default
+
 Authentication uses **Entra ID (Azure AD) App Registrations** with JWT bearer tokens and a **two-app model**:
 
 | App Registration | Audience | Purpose |
@@ -253,7 +260,39 @@ The APIM policy (`policies/entra-jwt-policy.xml`) validates incoming tokens agai
 | `aud` | Audience — validates the token is intended for this API |
 | `azp` / `appid` | Authorized Party — identifies the calling client application (`azp` for delegated tokens, `appid` for client_credentials) |
 
-> **Subscription keys are disabled.** All authentication uses standard `Authorization: Bearer <token>` headers validated by Entra ID.
+> **Subscription keys are disabled.** All authentication uses standard `Authorization: Bearer <token>` headers validated by the configured identity provider.
+
+### Keycloak OIDC — Alternative
+
+To use Keycloak instead of Entra ID, set `AuthProvider=Keycloak` in the configmap/appsettings and configure the Keycloak section:
+
+```yaml
+# Kubernetes configmap
+AuthProvider: "Keycloak"
+Keycloak__Authority: "https://keycloak.example.com/realms/myrealm"
+Keycloak__Audience: "ai-policy-engine"
+Keycloak__ClientId: "ai-policy-engine-api"        # Confidential client (backend)
+Keycloak__FrontendClientId: "ai-policy-engine-ui"  # Public client (SPA)
+Keycloak__Realm: "myrealm"
+Keycloak__FrontendUrl: "https://keycloak.example.com"
+Keycloak__RequireHttpsMetadata: "true"
+```
+
+**Required Keycloak roles** (create as realm roles or client roles):
+
+| Role | Purpose |
+|------|---------|
+| `AIPolicy.Admin` | Create/edit/delete plans, clients, pricing, routing policies |
+| `AIPolicy.Apim` | APIM service-to-service calls (precheck, log ingest) |
+| `AIPolicy.Export` | Access to data export endpoints |
+
+Ensure roles are included in the `roles` claim of the access token via a Keycloak protocol mapper.
+
+**APIM integration**: Use `policies/keycloak-jwt-policy.xml` instead of `entra-jwt-policy.xml`. Configure these APIM named values:
+- `KeycloakOpenIdConfigUrl` — OIDC discovery URL
+- `KeycloakTokenEndpoint` — Token endpoint for client_credentials
+- `AIPolicyEngineApiBaseUrl` — Backend API URL
+- `AIPolicyEngineApimClientId` / `AIPolicyEngineApimClientSecret` — APIM service account credentials
 
 ### Multi-Tenant Customer Model
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -136,6 +136,7 @@ module "gateway" {
   container_app_fqdn               = module.compute.container_app_fqdn
   container_app_id                 = module.compute.container_app_id
   container_app_principal_id       = module.compute.container_app_principal_id
+  create_container_app_role        = true
   api_app_id                       = module.identity.api_app_id
   gateway_app_id                   = module.identity.gateway_app_id
   tenant_id                        = module.identity.tenant_id

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -41,10 +41,16 @@ resource "azurerm_storage_account" "this" {
   min_tls_version                 = "TLS1_2"
   shared_access_key_enabled       = false
   default_to_oauth_authentication = true
+  public_network_access_enabled   = false
   tags                            = var.tags
 
   identity {
     type = "SystemAssigned"
+  }
+
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
   }
 }
 

--- a/infra/terraform/modules/gateway/main.tf
+++ b/infra/terraform/modules/gateway/main.tf
@@ -249,7 +249,7 @@ resource "azurerm_role_definition" "container_app_apim_manager" {
 }
 
 resource "azurerm_role_assignment" "container_app_apim_manager" {
-  count = var.container_app_principal_id != "" ? 1 : 0
+  count = var.create_container_app_role ? 1 : 0
 
   scope              = azurerm_api_management.this.id
   role_definition_id = azurerm_role_definition.container_app_apim_manager.role_definition_resource_id

--- a/infra/terraform/modules/gateway/variables.tf
+++ b/infra/terraform/modules/gateway/variables.tf
@@ -62,6 +62,12 @@ variable "container_app_principal_id" {
   default     = ""
 }
 
+variable "create_container_app_role" {
+  description = "Whether to create the APIM role assignment for the Container App. Use instead of checking container_app_principal_id in count to avoid unknown-at-plan-time errors."
+  type        = bool
+  default     = false
+}
+
 variable "api_app_id" {
   description = "Application (client) ID of the AI Policy API app registration."
   type        = string

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aipolicyengine-config
+  namespace: apim
+data:
+
+  # ASPNET Core settings
+  ASPNETCORE_ENVIRONMENT: "Production"
+  ASPNETCORE_URLS: "http://+:8080"
+  AllowedHosts: "*"
+
+  # Entra ID JWT authentication
+  AzureAd__Instance: "https://login.microsoftonline.com/"
+  AzureAd__TenantId: "<your-tenant-id>"
+  AzureAd__ClientId: "<your-app-registration-client-id>"
+  AzureAd__Audience: "<your-audience>"
+
+  # Authentication provider toggle: "AzureAd" or "Keycloak"
+  AuthProvider: "AzureAd"
+
+  # Keycloak OIDC authentication (used when AuthProvider=Keycloak)
+  Keycloak__Authority: ""
+  Keycloak__Audience: ""
+  Keycloak__ClientId: ""
+  Keycloak__RequireHttpsMetadata: "true"
+  Keycloak__FrontendUrl: ""
+  Keycloak__Realm: ""
+  Keycloak__FrontendClientId: ""
+
+  # Usage policy defaults
+  UsagePolicy__BillingCycleStartDay: "1"
+  UsagePolicy__AggregatedLogRetentionDays: "30"
+  UsagePolicy__TraceRetentionDays: "30"
+
+  # Purview (DLP) — non-sensitive settings
+  PURVIEW_TENANT_ID: "<your-tenant-id>"
+  PURVIEW_APP_NAME: "AI Policy Engine API"
+  PURVIEW_APP_LOCATION: ""        # optional URI
+  PURVIEW_IGNORE_EXCEPTIONS: "false"
+  PURVIEW_BACKGROUND_JOB_LIMIT: "100"
+  PURVIEW_MAX_CONCURRENT_CONSUMERS: "10"
+  PURVIEW_BLOCK_ENABLED: "false"  # set true to enforce DLP blocking
+
+  # OpenTelemetry (optional — omit if not using a collector)
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-policy-engine
+  namespace: apim
+  labels:
+    app: ai-policy-engine
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ai-policy-engine
+  template:
+    metadata:
+      labels:
+        app: ai-policy-engine
+    spec:
+      # Optional: pin to specific nodes if needed
+      # nodeSelector:
+      #   kubernetes.io/os: linux
+
+      containers:
+        - name: ai-policy-engine
+          image: your-registry/ai-policy-engine:latest   # <-- replace with your registry
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+
+          # Load non-sensitive config from ConfigMap
+          envFrom:
+            - configMapRef:
+                name: aipolicyengine-config
+            - secretRef:
+                name: aipolicyengine-secrets
+
+          # Health probes — Aspire ServiceDefaults exposes /health and /alive
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+
+      # If your registry requires pull credentials:
+      # imagePullSecrets:
+      #   - name: registry-credentials

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apim

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aipolicyengine-secrets
+  namespace: apim
+type: Opaque
+stringData:
+  # Redis — StackExchange.Redis connection string format
+  # e.g. "myredis.redis.cache.windows.net:6380,password=<key>,ssl=True,abortConnect=False"
+  ConnectionStrings__redis: "<redis-connection-string>"
+
+  # Cosmos DB — account endpoint URI (used with DefaultAzureCredential/workload identity)
+  # or full connection string: "AccountEndpoint=https://...;AccountKey=..."
+  ConnectionStrings__aipolicy: "https://<account>.documents.azure.com:443/"
+
+  # Application Insights (omit if not using)
+  APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=...;IngestionEndpoint=..."
+
+  # Purview DLP client app ID — triggers full Purview integration when set
+  # Leave empty / omit to use the no-op implementation
+  PURVIEW_CLIENT_APP_ID: "<purview-client-app-id>"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-policy-engine
+  namespace: apim
+  labels:
+    app: ai-policy-engine
+spec:
+  selector:
+    app: ai-policy-engine
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+  # ClusterIP makes the service reachable only within the cluster.
+  # Your existing APIM should reach this via the cluster's internal DNS:
+  #   http://ai-policy-engine.apim.svc.cluster.local
+  # or via an Ingress / NodePort if APIM is external to the cluster.
+  type: ClusterIP

--- a/k8s/virtualservice.yaml
+++ b/k8s/virtualservice.yaml
@@ -1,0 +1,112 @@
+# Istio Gateway + VirtualService for the Chargeback API.
+# Replaces ingress.yaml when using the Istio ingress gateway.
+#
+# Prerequisites:
+#   - Istio installed in the cluster
+#   - An Istio IngressGateway running (default: istio-system namespace)
+#   - A DNS record pointing your hostname at the IngressGateway LoadBalancer IP
+#
+# Apply with:
+#   kubectl apply -f k8s/virtualservice.yaml
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: aipolicyengine-gateway
+  namespace: apim
+spec:
+  selector:
+    # Targets the default Istio ingress gateway pod.
+    # Change if you use a dedicated ingress gateway (e.g. istio: ingressgateway-internal).
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - ai-policy-engine.internal.example.com
+      # Optional: redirect all HTTP to HTTPS by uncommenting below
+      # tls:
+      #   httpsRedirect: true
+
+    # Uncomment for TLS termination at the ingress gateway.
+    # Requires a TLS credential (kubectl create secret tls chargeback-tls -n istio-system ...).
+    # - port:
+    #     number: 443
+    #     name: https
+    #     protocol: HTTPS
+    #   hosts:
+    #     - ai-policy-engine.internal.example.com
+    #   tls:
+    #     mode: SIMPLE
+    #     credentialName: ai-policy-engine-tls   # Secret must be in istio-system namespace
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: aipolicyengine-api
+  namespace: apim
+spec:
+  hosts:
+    - ai-policy-engine.internal.example.com
+  gateways:
+    - aipolicyengine-gateway
+    # Also allow mesh-internal traffic (e.g. from APIM running inside the cluster)
+    - mesh
+  http:
+    # Health probe paths — bypass any auth/retry so k8s probes always succeed
+    - match:
+        - uri:
+            prefix: /health
+        - uri:
+            prefix: /alive
+      route:
+        - destination:
+            host: aipolicyengine-api
+            port:
+              number: 80
+      retries:
+        attempts: 0
+
+    # API routes
+    - match:
+        - uri:
+            prefix: /api
+        - uri:
+            prefix: /chargeback
+        - uri:
+            prefix: /openapi
+        - uri:
+            exact: /config
+      route:
+        - destination:
+            host: aipolicyengine-api
+            port:
+              number: 80
+    - match:
+      - uri:
+          prefix: /ws
+      headers:
+        upgrade:
+          exact: websocket
+      timeout: 30s
+      retries:
+        attempts: 2
+        perTryTimeout: 10s
+        retryOn: gateway-error,connect-failure,retriable-4xx
+      route:
+        - destination:
+            host: aipolicyengine-api
+            port:
+              number: 80
+
+    # React SPA + static assets (catch-all)
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: aipolicyengine-api
+            port:
+              number: 80

--- a/policies/keycloak-jwt-policy.md
+++ b/policies/keycloak-jwt-policy.md
@@ -1,0 +1,65 @@
+# APIM Policy Analysis: `keycloak-jwt-policy.xml`
+
+This is an **Azure API Management (APIM) policy** that validates Keycloak-issued JWT tokens instead of Azure AD tokens. It is functionally equivalent to `entra-jwt-policy.xml` but uses Keycloak's OpenID Connect endpoints and client_credentials flow for backend authentication.
+
+---
+
+## Prerequisites
+
+### APIM Named Values
+
+| Named Value | Description |
+|-------------|-------------|
+| `KeycloakOpenIdConfigUrl` | Keycloak OIDC discovery URL (e.g., `https://<host>/realms/<realm>/.well-known/openid-configuration`) |
+| `KeycloakTokenEndpoint` | Keycloak token endpoint (e.g., `https://<host>/realms/<realm>/protocol/openid-connect/token`) |
+| `ExpectedAudience` | The expected `aud` claim in the JWT token |
+| `AIPolicyEngineApiBaseUrl` | Base URL of the AI Policy Engine API |
+| `AIPolicyEngineApimClientId` | Keycloak client ID for APIM's service account |
+| `AIPolicyEngineApimClientSecret` | Keycloak client secret for APIM's service account (store as Secret named value) |
+
+---
+
+## Key Differences from `entra-jwt-policy.xml`
+
+### 1. JWT Validation
+
+Uses Keycloak's OIDC discovery endpoint instead of Azure AD's `/common/.well-known/openid-configuration`.
+
+### 2. Claim Extraction
+
+| Variable | Keycloak Claim | Notes |
+|----------|---------------|-------|
+| `tenantId` | `tenant_id` (custom) or extracted from issuer URL | Keycloak doesn't have a native `tid` claim; uses custom mapper or parses realm from issuer |
+| `clientAppId` | `azp` or `client_id` | `azp` for authorization code flow, `client_id` for client_credentials |
+| `audience` | `aud` | Same as Entra |
+
+### 3. Backend Authentication
+
+Instead of Azure Managed Identity, this policy acquires a token from Keycloak using the **client_credentials** grant:
+
+```xml
+<send-request mode="new" response-variable-name="keycloakTokenResponse" ...>
+    <set-url>{{KeycloakTokenEndpoint}}</set-url>
+    <set-method>POST</set-method>
+    <set-body>grant_type=client_credentials&client_id=...&client_secret=...</set-body>
+</send-request>
+```
+
+The resulting access token is used for both the pre-check call and the fire-and-forget log call.
+
+### 4. Named Value References
+
+- `{{ContainerAppUrl}}` → `{{AIPolicyEngineApiBaseUrl}}`
+- `{{ContainerAppAudience}}` → removed (token acquired via client_credentials)
+- Managed identity → Keycloak client_credentials token
+
+---
+
+## Keycloak Setup Requirements
+
+1. **Create a client** for the AI Policy Engine API (the resource server / audience)
+2. **Create a client** for APIM with:
+   - `Service accounts roles` enabled (for client_credentials)
+   - Appropriate roles/scopes to access the API
+3. **Add a custom protocol mapper** (optional) to include `tenant_id` in tokens if multi-tenancy is needed
+4. **Configure audience mapper** on the API client to ensure `aud` claim is present in tokens

--- a/policies/keycloak-jwt-policy.xml
+++ b/policies/keycloak-jwt-policy.xml
@@ -1,0 +1,274 @@
+<!--
+    Keycloak OIDC JWT validation policy for AI Policy Engine.
+    
+    This policy validates JWT tokens issued by Keycloak instead of Azure AD.
+    APIM authenticates to the AI Policy Engine backend using a Keycloak
+    client_credentials token (service account) instead of managed identity.
+
+    Required APIM Named Values:
+    - AIPolicyEngineApiBaseUrl: Base URL of the AI Policy Engine API
+    - AIPolicyEngineApimClientId: Keycloak client ID for APIM service account
+    - AIPolicyEngineApimClientSecret: Keycloak client secret for APIM service account
+    - KeycloakTokenEndpoint: Keycloak token endpoint (e.g., https://<host>/realms/<realm>/protocol/openid-connect/token)
+    - KeycloakOpenIdConfigUrl: Keycloak OIDC discovery URL (e.g., https://<host>/realms/<realm>/.well-known/openid-configuration)
+    - ExpectedAudience: The expected audience claim in the JWT token
+-->
+<policies>
+	<inbound>
+		<base />
+		<!-- Validate Keycloak JWT token using OIDC discovery -->
+		<validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized. Access token is missing or invalid.">
+			<openid-config url="{{KeycloakOpenIdConfigUrl}}" />
+			<required-claims>
+				<claim name="aud" match="all">
+					<value>{{ExpectedAudience}}</value>
+				</claim>
+			</required-claims>
+		</validate-jwt>
+		<!-- Extract JWT claims into variables (Keycloak claim names) -->
+		<set-variable name="tenantId" value="@{
+			var jwt = context.Request.Headers.GetValueOrDefault("Authorization","").Split(' ').Last().AsJwt();
+			// Keycloak doesn't have a 'tid' claim by default; use a custom claim or the issuer realm
+			var tid = jwt?.Claims.GetValueOrDefault("tenant_id","");
+			if (string.IsNullOrEmpty(tid)) {
+				// Extract realm from issuer (e.g., https://keycloak.example.com/realms/myrealm)
+				var iss = jwt?.Claims.GetValueOrDefault("iss","");
+				if (!string.IsNullOrEmpty(iss)) {
+					var parts = iss.Split('/');
+					tid = parts.Length > 0 ? parts[parts.Length - 1] : "";
+				}
+			}
+			return tid;
+		}" />
+		<set-variable name="clientAppId" value="@{
+			var jwt = context.Request.Headers.GetValueOrDefault("Authorization","").Split(' ').Last().AsJwt();
+			// azp is the authorized party (client that requested the token)
+			var azp = jwt?.Claims.GetValueOrDefault("azp","");
+			if (!string.IsNullOrEmpty(azp)) return azp;
+			// Fallback to client_id claim for client_credentials grants
+			return jwt?.Claims.GetValueOrDefault("client_id","");
+		}" />
+		<set-variable name="audience" value="@(context.Request.Headers.GetValueOrDefault("Authorization","").Split(' ').Last().AsJwt()?.Claims.GetValueOrDefault("aud",""))" />
+		<!-- Set variables for later use -->
+		<set-variable name="requestBody" value="@(context.Request.Body.As<string>(preserveContent: true))" />
+		<!-- Extract deploymentId from URL path (/deployments/{id}/...) or fall back to
+		     the "model" field in the JSON request body for routes like /responses, /models -->
+		<set-variable name="deploymentId" value="@{
+			var path = context.Request.Url.Path;
+			var marker = "/deployments/";
+			var idx = path.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+			if (idx >= 0) {
+				var rest = path.Substring(idx + marker.Length);
+				var slash = rest.IndexOf('/');
+				if (slash >= 0) { return rest.Substring(0, slash); }
+				return rest;
+			}
+			try {
+				var body = context.Variables.GetValueOrDefault<string>("requestBody");
+				if (!string.IsNullOrEmpty(body)) {
+					var json = Newtonsoft.Json.Linq.JObject.Parse(body);
+					var model = json["model"]?.ToString();
+					if (!string.IsNullOrEmpty(model)) { return model; }
+				}
+			} catch { }
+			var segments = path.Split('/');
+			if (segments.Length > 1) { return segments[segments.Length - 1]; }
+			return "unknown";
+		}" />
+		<!-- Acquire a token from Keycloak using client_credentials for the AI Policy Engine backend -->
+		<send-request mode="new" response-variable-name="keycloakTokenResponse" timeout="10" ignore-error="false">
+			<set-url>{{KeycloakTokenEndpoint}}</set-url>
+			<set-method>POST</set-method>
+			<set-header name="Content-Type" exists-action="override">
+				<value>application/x-www-form-urlencoded</value>
+			</set-header>
+			<set-body>@{
+				return "grant_type=client_credentials&client_id={{AIPolicyEngineApimClientId}}&client_secret={{AIPolicyEngineApimClientSecret}}&audience={{ExpectedAudience}}";
+			}</set-body>
+		</send-request>
+		<set-variable name="backend-access-token" value="@{
+			var response = ((IResponse)context.Variables["keycloakTokenResponse"]).Body.As<JObject>();
+			return (string)response["access_token"];
+		}" />
+		<!-- Pre-check: verify client has a valid plan and is within quota BEFORE calling OpenAI -->
+		<set-variable name="containerAppBaseUrl" value="{{AIPolicyEngineApiBaseUrl}}" />
+		<send-request mode="new" response-variable-name="precheckResponse" timeout="10" ignore-error="true">
+			<set-url>@((string)context.Variables["containerAppBaseUrl"] + "/api/precheck/" + (string)context.Variables["clientAppId"] + "/" + (string)context.Variables["tenantId"] + "?deploymentId=" + (string)context.Variables["deploymentId"])</set-url>
+			<set-method>GET</set-method>
+			<set-header name="Authorization" exists-action="override">
+				<value>@("Bearer " + (string)context.Variables["backend-access-token"])</value>
+			</set-header>
+		</send-request>
+		<choose>
+			<when condition="@(context.Variables["precheckResponse"] == null || ((IResponse)context.Variables["precheckResponse"]).StatusCode == 401)">
+				<return-response>
+					<set-status code="401" reason="Unauthorized" />
+					<set-header name="Content-Type" exists-action="override"><value>application/json</value></set-header>
+					<set-body>@{
+						var resp = context.Variables["precheckResponse"] as IResponse;
+						return resp != null ? resp.Body.As<string>() : "{\"error\":\"Pre-check failed — could not reach authorization service\"}";
+					}</set-body>
+				</return-response>
+			</when>
+			<when condition="@(((IResponse)context.Variables["precheckResponse"]).StatusCode == 403)">
+				<return-response>
+					<set-status code="403" reason="Forbidden" />
+					<set-header name="Content-Type" exists-action="override"><value>application/json</value></set-header>
+					<set-body>@(((IResponse)context.Variables["precheckResponse"]).Body.As<string>())</set-body>
+				</return-response>
+			</when>
+			<when condition="@(((IResponse)context.Variables["precheckResponse"]).StatusCode == 429)">
+				<return-response>
+					<set-status code="429" reason="Too Many Requests" />
+					<set-header name="Content-Type" exists-action="override"><value>application/json</value></set-header>
+					<set-body>@(((IResponse)context.Variables["precheckResponse"]).Body.As<string>())</set-body>
+				</return-response>
+			</when>
+			<when condition="@(((IResponse)context.Variables["precheckResponse"]).StatusCode != 200)">
+				<return-response>
+					<set-status code="500" reason="Internal Server Error" />
+					<set-header name="Content-Type" exists-action="override"><value>application/json</value></set-header>
+					<set-body>{"error":"Pre-authorization check failed"}</set-body>
+				</return-response>
+			</when>
+		</choose>
+		<!-- ══════════════════════════════════════════════════════════════════════════
+		     AUTO-ROUTER — Deployment routing based on precheck response.
+		     ══════════════════════════════════════════════════════════════════════════ -->
+		<set-variable name="routedDeployment"
+			value="@(((IResponse)context.Variables["precheckResponse"]).Body.As<JObject>(preserveContent: true)["routedDeployment"]?.ToString())" />
+		<set-variable name="routingPolicyId"
+			value="@(((IResponse)context.Variables["precheckResponse"]).Body.As<JObject>(preserveContent: true)["routingPolicyId"]?.ToString())" />
+		<choose>
+			<when condition="@(!string.IsNullOrEmpty((string)context.Variables["routedDeployment"]) &amp;&amp; (string)context.Variables["routedDeployment"] != (string)context.Variables["deploymentId"])">
+				<set-variable name="originalDeploymentId" value="@((string)context.Variables["deploymentId"])" />
+				<set-variable name="deploymentId" value="@((string)context.Variables["routedDeployment"])" />
+				<rewrite-uri template="@{
+					var path = context.Request.Url.Path;
+					var original = (string)context.Variables["originalDeploymentId"];
+					var routed = (string)context.Variables["routedDeployment"];
+					return path.Replace($"/deployments/{original}/", $"/deployments/{routed}/");
+				}" />
+			</when>
+		</choose>
+		<!-- Set the backend service to the Azure OpenAI endpoint -->
+		<set-backend-service id="apim-generated-policy" backend-id="openAiBackend" />
+		<!-- Use managed identity to authenticate against the Azure Cognitive Services -->
+		<authentication-managed-identity resource="https://cognitiveservices.azure.com/" />
+		<!-- Capture the request body as text and add the 'stream_options' property if 'stream' is set to true -->
+		<set-body>@{
+            var rawBody = context.Variables.GetValueOrDefault<string>("requestBody");
+            var requestBody = Newtonsoft.Json.Linq.JObject.Parse(rawBody);
+            if (requestBody["stream"] != null && (bool)requestBody["stream"] == true) {
+                requestBody["stream_options"] = Newtonsoft.Json.Linq.JObject.Parse(@"{""include_usage"":true}");
+            }
+            return requestBody.ToString();
+        }</set-body>
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+		<!-- Capture the raw response as text -->
+		<set-variable name="responseBodyText" value="@{
+            return context.Response.Body.As<string>(preserveContent: true);
+        }" />
+		<!-- Parse the response: if streaming, extract the last chunk with usage; otherwise parse as JSON -->
+		<set-variable name="parsedResponse" value="@{
+            string txt = (string)context.Variables["responseBodyText"];
+            if (txt.TrimStart().StartsWith("data:")) {
+                var lines = txt.Split(new[] {'\n', '\r'}, StringSplitOptions.RemoveEmptyEntries);
+                var chunkLine = lines
+                    .Where(l => l.Trim().StartsWith("data:") && l.Contains("\"usage\"") && !l.Contains("[DONE]"))
+                    .LastOrDefault();
+                if (chunkLine != null) {
+                    int index = chunkLine.IndexOf('{');
+                    string jsonPart = chunkLine.Substring(index);
+                    return Newtonsoft.Json.Linq.JObject.Parse(jsonPart);
+                }
+                return null;
+            } else {
+                return Newtonsoft.Json.Linq.JObject.Parse(txt);
+            }
+        }" />
+		<set-variable name="parsedResponseString" value="@{
+            var parsedResponse = context.Variables.GetValueOrDefault<Newtonsoft.Json.Linq.JObject>("parsedResponse");
+            return parsedResponse != null ? parsedResponse.ToString() : string.Empty;
+        }" />
+		<!-- Fire-and-forget: send usage data to AI Policy API -->
+		<send-one-way-request mode="new">
+			<set-url>{{AIPolicyEngineApiBaseUrl}}/api/log</set-url>
+			<set-method>POST</set-method>
+			<set-header name="Content-Type" exists-action="override">
+				<value>application/json</value>
+			</set-header>
+			<set-header name="Authorization" exists-action="override">
+				<value>@("Bearer " + (string)context.Variables["backend-access-token"])</value>
+			</set-header>
+			<set-body>@{
+				var requestBodyRaw = context.Variables.GetValueOrDefault<string>("requestBody");
+				var parsedResponseString = context.Variables.GetValueOrDefault<string>("parsedResponseString");
+				var deploymentId = context.Variables.GetValueOrDefault<string>("deploymentId");
+				var requestedDeploymentId = context.Variables.ContainsKey("originalDeploymentId")
+					? context.Variables.GetValueOrDefault<string>("originalDeploymentId")
+					: deploymentId;
+				object requestBodyValue = null;
+				if (!string.IsNullOrEmpty(requestBodyRaw)) {
+					try {
+						requestBodyValue = Newtonsoft.Json.Linq.JToken.Parse(requestBodyRaw);
+					} catch {
+						requestBodyValue = requestBodyRaw;
+					}
+				}
+				object responseBodyValue = null;
+				if (!string.IsNullOrEmpty(parsedResponseString)) {
+					try {
+						responseBodyValue = Newtonsoft.Json.Linq.JToken.Parse(parsedResponseString);
+					} catch {
+						responseBodyValue = parsedResponseString;
+					}
+				}
+				var payload = new Newtonsoft.Json.Linq.JObject();
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("tenantId", (string)context.Variables.GetValueOrDefault("tenantId", "")));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("clientAppId", (string)context.Variables.GetValueOrDefault("clientAppId", "")));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("audience", (string)context.Variables.GetValueOrDefault("audience", "")));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("requestBody", requestBodyValue));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("responseBody", responseBodyValue));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("deploymentId", deploymentId ?? ""));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("requestedDeploymentId", requestedDeploymentId ?? ""));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("routedDeployment", context.Variables.GetValueOrDefault<string>("routedDeployment") ?? ""));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("routingPolicyId", context.Variables.GetValueOrDefault<string>("routingPolicyId") ?? ""));
+				payload.Add(new Newtonsoft.Json.Linq.JProperty("correlationId", context.RequestId.ToString()));
+				return payload.ToString();
+			}</set-body>
+		</send-one-way-request>
+	</outbound>
+	<on-error>
+		<base />
+		<set-header name="ErrorSource" exists-action="override">
+			<value>@(context.LastError.Source)</value>
+		</set-header>
+		<set-header name="ErrorReason" exists-action="override">
+			<value>@(context.LastError.Reason)</value>
+		</set-header>
+		<set-header name="ErrorMessage" exists-action="override">
+			<value>@(context.LastError.Message)</value>
+		</set-header>
+		<set-header name="ErrorScope" exists-action="override">
+			<value>@(context.LastError.Scope)</value>
+		</set-header>
+		<set-header name="ErrorSection" exists-action="override">
+			<value>@(context.LastError.Section)</value>
+		</set-header>
+		<set-header name="ErrorPath" exists-action="override">
+			<value>@(context.LastError.Path)</value>
+		</set-header>
+		<set-header name="ErrorPolicyId" exists-action="override">
+			<value>@(context.LastError.PolicyId)</value>
+		</set-header>
+		<set-header name="ErrorStatusCode" exists-action="override">
+			<value>@(context.Response.StatusCode.ToString())</value>
+		</set-header>
+	</on-error>
+</policies>

--- a/src/AIPolicyEngine.Api/Endpoints/AccessProfileEndpoints.cs
+++ b/src/AIPolicyEngine.Api/Endpoints/AccessProfileEndpoints.cs
@@ -149,6 +149,13 @@ public static class AccessProfileEndpoints
                 profile.PlanId = body.PlanId.Trim();
             }
 
+            if (body.Blocked.HasValue)
+                profile.Blocked = body.Blocked.Value;
+
+            // Validate final state: unblocked profiles require a plan
+            if (!profile.Blocked && string.IsNullOrWhiteSpace(profile.PlanId))
+                return Results.BadRequest(new { error = "planId is required when not blocking" });
+
             if (body.RoutingPolicyId is not null)
             {
                 var normalizedRoutingPolicyId = NormalizeOptional(body.RoutingPolicyId);
@@ -258,16 +265,29 @@ public static class AccessProfileEndpoints
     {
         if (string.IsNullOrWhiteSpace(body.ClientAppId) ||
             string.IsNullOrWhiteSpace(body.TenantId) ||
-            string.IsNullOrWhiteSpace(body.ApiId) ||
-            string.IsNullOrWhiteSpace(body.PlanId))
+            string.IsNullOrWhiteSpace(body.ApiId))
         {
-            return new BuildProfileResult(Results.BadRequest("clientAppId, tenantId, apiId, and planId are required"), "clientAppId, tenantId, apiId, and planId are required", null, TryBuildProfileId(body));
+            return new BuildProfileResult(Results.BadRequest("clientAppId, tenantId, and apiId are required"), "clientAppId, tenantId, and apiId are required", null, TryBuildProfileId(body));
         }
 
-        var planId = body.PlanId.Trim();
-        var plan = await planRepository.GetAsync(planId);
-        if (plan is null)
-            return new BuildProfileResult(Results.BadRequest($"Plan '{planId}' not found"), $"Plan '{planId}' not found", null, TryBuildProfileId(body));
+        if (!body.Blocked && string.IsNullOrWhiteSpace(body.PlanId))
+        {
+            return new BuildProfileResult(Results.BadRequest("planId is required when not blocking"), "planId is required when not blocking", null, TryBuildProfileId(body));
+        }
+
+        var planId = body.PlanId?.Trim() ?? string.Empty;
+        if (!body.Blocked)
+        {
+            var plan = await planRepository.GetAsync(planId);
+            if (plan is null)
+                return new BuildProfileResult(Results.BadRequest($"Plan '{planId}' not found"), $"Plan '{planId}' not found", null, TryBuildProfileId(body));
+        }
+        else if (!string.IsNullOrWhiteSpace(body.PlanId))
+        {
+            var plan = await planRepository.GetAsync(planId);
+            if (plan is null)
+                return new BuildProfileResult(Results.BadRequest($"Plan '{planId}' not found"), $"Plan '{planId}' not found", null, TryBuildProfileId(body));
+        }
 
         var routingPolicyId = NormalizeOptional(body.RoutingPolicyId);
         if (routingPolicyId is not null)
@@ -295,6 +315,7 @@ public static class AccessProfileEndpoints
             PlanId = planId,
             RoutingPolicyId = routingPolicyId,
             AllowedDeployments = NormalizeAllowedDeployments(body.AllowedDeployments),
+            Blocked = body.Blocked,
             Enabled = body.Enabled,
             CreatedBy = GetActor(user),
             CreatedAt = now,

--- a/src/AIPolicyEngine.Api/Endpoints/AuthConfigEndpoints.cs
+++ b/src/AIPolicyEngine.Api/Endpoints/AuthConfigEndpoints.cs
@@ -1,0 +1,52 @@
+namespace AIPolicyEngine.Api.Endpoints;
+
+/// <summary>
+/// Exposes runtime authentication configuration so the SPA can discover
+/// which identity provider to use without baking values into the JS bundle.
+/// </summary>
+public static class AuthConfigEndpoints
+{
+    public static IEndpointRouteBuilder MapAuthConfigEndpoints(this IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/api/auth-config", GetAuthConfig)
+            .WithName("GetAuthConfig")
+            .WithDescription("Returns runtime auth provider configuration for the SPA")
+            .AllowAnonymous()
+            .Produces<object>();
+
+        return routes;
+    }
+
+    private static IResult GetAuthConfig(IConfiguration config)
+    {
+        var provider = config.GetValue<string>("AuthProvider") ?? "AzureAd";
+
+        if (provider.Equals("Keycloak", StringComparison.OrdinalIgnoreCase))
+        {
+            var kc = config.GetSection("Keycloak");
+            return Results.Ok(new
+            {
+                authProvider = "Keycloak",
+                authority = kc["Authority"] ?? "",
+                clientId = kc["FrontendClientId"] ?? kc["ClientId"] ?? "",
+                audience = kc["Audience"] ?? "",
+                realm = kc["Realm"] ?? "",
+                frontendUrl = kc["FrontendUrl"] ?? "",
+            });
+        }
+
+        return Results.Ok(new
+        {
+            authProvider = "AzureAd",
+            clientId = config["AzureAd:ClientId"] ?? "",
+            tenantId = config["AzureAd:TenantId"] ?? "",
+            authority = config["AzureAd:Instance"] is string inst && config["AzureAd:TenantId"] is string tid
+                ? $"{inst.TrimEnd('/')}/{tid}"
+                : "",
+            audience = config["AzureAd:Audience"] ?? "",
+            scope = config["AzureAd:Audience"] is string aud && !string.IsNullOrEmpty(aud)
+                ? $"api://{aud}/access_as_user"
+                : "",
+        });
+    }
+}

--- a/src/AIPolicyEngine.Api/Endpoints/AuthConfigEndpoints.cs
+++ b/src/AIPolicyEngine.Api/Endpoints/AuthConfigEndpoints.cs
@@ -45,7 +45,7 @@ public static class AuthConfigEndpoints
                 : "",
             audience = config["AzureAd:Audience"] ?? "",
             scope = config["AzureAd:Audience"] is string aud && !string.IsNullOrEmpty(aud)
-                ? $"api://{aud}/access_as_user"
+                ? $"{(aud.StartsWith("api://") ? aud : $"api://{aud}")}/access_as_user"
                 : "",
         });
     }

--- a/src/AIPolicyEngine.Api/Endpoints/PrecheckEndpoints.cs
+++ b/src/AIPolicyEngine.Api/Endpoints/PrecheckEndpoints.cs
@@ -61,6 +61,23 @@ public static class PrecheckEndpoints
 
         var resolved = await accessProfileResolver.ResolveAsync(clientAppId, tenantId, apiId, operationId);
         var assignment = await clientRepo.GetAsync($"{clientAppId}:{tenantId}");
+
+        if (resolved is { Blocked: true })
+        {
+            return Results.Json(
+                new
+                {
+                    error = "Access blocked by access profile",
+                    clientAppId,
+                    tenantId,
+                    apiId,
+                    operationId,
+                    accessProfileId = resolved.AccessProfileId,
+                    deniedBy = "access-profile-blocked"
+                },
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
         if (resolved is null)
         {
             if (assignment is null)

--- a/src/AIPolicyEngine.Api/Models/AccessProfile.cs
+++ b/src/AIPolicyEngine.Api/Models/AccessProfile.cs
@@ -19,6 +19,7 @@ public sealed class AccessProfile
     public string PlanId { get; set; } = string.Empty;
     public string? RoutingPolicyId { get; set; }
     public List<string> AllowedDeployments { get; set; } = [];
+    public bool Blocked { get; set; }
     public bool Enabled { get; set; } = true;
     public string CreatedBy { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/AIPolicyEngine.Api/Models/AccessProfileRequests.cs
+++ b/src/AIPolicyEngine.Api/Models/AccessProfileRequests.cs
@@ -9,6 +9,7 @@ public sealed class AccessProfileCreateRequest
     public string PlanId { get; set; } = string.Empty;
     public string? RoutingPolicyId { get; set; }
     public List<string>? AllowedDeployments { get; set; }
+    public bool Blocked { get; set; }
     public bool Enabled { get; set; } = true;
 }
 
@@ -17,6 +18,7 @@ public sealed class AccessProfileUpdateRequest
     public string? PlanId { get; set; }
     public string? RoutingPolicyId { get; set; }
     public List<string>? AllowedDeployments { get; set; }
+    public bool? Blocked { get; set; }
     public bool? Enabled { get; set; }
 }
 

--- a/src/AIPolicyEngine.Api/Models/AccessProfileResponses.cs
+++ b/src/AIPolicyEngine.Api/Models/AccessProfileResponses.cs
@@ -23,6 +23,7 @@ public sealed class ResolvedAccessProfile
     public string PlanId { get; set; } = string.Empty;
     public string? RoutingPolicyId { get; set; }
     public List<string> AllowedDeployments { get; set; } = [];
+    public bool Blocked { get; set; }
     public string? AccessProfileId { get; set; }
     public string? SourceProfileId
     {

--- a/src/AIPolicyEngine.Api/Program.cs
+++ b/src/AIPolicyEngine.Api/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Security.Claims;
 using System.Threading.Channels;
 using Azure.Identity;
 using Azure.ResourceManager;
@@ -7,7 +8,9 @@ using AIPolicyEngine.Api.Models;
 using AIPolicyEngine.Api.Services;
 using AIPolicyEngine.Api.Services.AccessProfiles;
 using AIPolicyEngine.Api.Services.ApimManagement;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
+using Microsoft.IdentityModel.Tokens;
 using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -140,9 +143,90 @@ builder.Services.AddOpenApi();
 // Purview integration for DLP policy validation and audit emission (Agent 365)
 builder.Services.AddPurviewServices(builder.Configuration);
 
-// Entra ID JWT Bearer authentication
-builder.Services.AddAuthentication()
-    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+// Authentication: supports AzureAd or Keycloak based on AuthProvider config
+var authProvider = builder.Configuration.GetValue<string>("AuthProvider") ?? "AzureAd";
+
+if (authProvider.Equals("Keycloak", StringComparison.OrdinalIgnoreCase))
+{
+    var keycloakSection = builder.Configuration.GetSection("Keycloak");
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
+        {
+            options.Authority = keycloakSection["Authority"];
+            options.Audience = keycloakSection["Audience"];
+            options.RequireHttpsMetadata = keycloakSection.GetValue<bool>("RequireHttpsMetadata", true);
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                // Keycloak uses "preferred_username" instead of "name"
+                NameClaimType = "preferred_username",
+                RoleClaimType = "roles"
+            };
+            // Extract roles from Keycloak's nested realm_access/resource_access claims
+            options.Events = new JwtBearerEvents
+            {
+                OnTokenValidated = context =>
+                {
+                    if (context.Principal?.Identity is ClaimsIdentity identity)
+                    {
+                        // Extract realm roles from realm_access.roles
+                        var realmAccess = context.Principal.FindFirst("realm_access");
+                        if (realmAccess != null)
+                        {
+                            try
+                            {
+                                var parsed = System.Text.Json.JsonDocument.Parse(realmAccess.Value);
+                                if (parsed.RootElement.TryGetProperty("roles", out var roles))
+                                {
+                                    foreach (var role in roles.EnumerateArray())
+                                    {
+                                        var roleValue = role.GetString();
+                                        if (!string.IsNullOrEmpty(roleValue))
+                                            identity.AddClaim(new Claim("roles", roleValue));
+                                    }
+                                }
+                            }
+                            catch { /* ignore malformed claim */ }
+                        }
+
+                        // Extract client roles from resource_access.<clientId>.roles
+                        var resourceAccess = context.Principal.FindFirst("resource_access");
+                        if (resourceAccess != null)
+                        {
+                            try
+                            {
+                                var parsed = System.Text.Json.JsonDocument.Parse(resourceAccess.Value);
+                                foreach (var client in parsed.RootElement.EnumerateObject())
+                                {
+                                    if (client.Value.TryGetProperty("roles", out var roles))
+                                    {
+                                        foreach (var role in roles.EnumerateArray())
+                                        {
+                                            var roleValue = role.GetString();
+                                            if (!string.IsNullOrEmpty(roleValue))
+                                                identity.AddClaim(new Claim("roles", roleValue));
+                                        }
+                                    }
+                                }
+                            }
+                            catch { /* ignore malformed claim */ }
+                        }
+                    }
+                    return Task.CompletedTask;
+                }
+            };
+        });
+}
+else
+{
+    // Entra ID JWT Bearer authentication (default)
+    builder.Services.AddAuthentication()
+        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+}
+
 builder.Services.AddAuthorizationBuilder()
     .AddPolicy("ExportPolicy", policy =>
         policy.RequireRole("AIPolicy.Export"))
@@ -186,6 +270,7 @@ app.UseAuthorization();
 app.UseWebSockets();
 
 // Map all endpoints
+app.MapAuthConfigEndpoints();
 app.MapLogIngestEndpoints();
 app.MapDashboardEndpoints();
 app.MapPlanEndpoints();

--- a/src/AIPolicyEngine.Api/Services/AccessProfiles/AccessProfileResolver.cs
+++ b/src/AIPolicyEngine.Api/Services/AccessProfiles/AccessProfileResolver.cs
@@ -58,6 +58,7 @@ public sealed class AccessProfileResolver : IAccessProfileResolver
         PlanId = profile.PlanId,
         RoutingPolicyId = profile.RoutingPolicyId,
         AllowedDeployments = profile.AllowedDeployments?.ToList() ?? [],
+        Blocked = profile.Blocked,
         AccessProfileId = profile.Id
     };
 }

--- a/src/AIPolicyEngine.Api/Services/ApimManagement/ApimCatalogService.cs
+++ b/src/AIPolicyEngine.Api/Services/ApimManagement/ApimCatalogService.cs
@@ -26,7 +26,7 @@ public sealed class ApimCatalogService : IApimCatalogService
         ArgumentNullException.ThrowIfNull(options);
 
         _armClient = armClient;
-        _resourceIdText = options.Value.ResourceId;
+        _resourceIdText = options.Value.ResourceId?.Trim() ?? string.Empty;
         _logger = logger;
     }
 

--- a/src/AIPolicyEngine.Api/Services/ApimManagement/ApimPolicyApplyService.cs
+++ b/src/AIPolicyEngine.Api/Services/ApimManagement/ApimPolicyApplyService.cs
@@ -160,7 +160,7 @@ public sealed class ApimPolicyApplyService : IApimPolicyApplyService
                 ?? throw new KeyNotFoundException($"APIM operation '{operationId}' was not found on API '{apiId}'.");
         }
 
-        var renderedTemplate = await _templateLibraryService.RenderAsync(request.TemplateId, request.Parameters, ct);
+        var renderedTemplate = await _templateLibraryService.RenderAsync(request.TemplateId, request.Parameters ?? [], ct);
         var existingAssignment = await _assignmentRepository.GetAsync(apiId, operationId, ct);
         var now = DateTime.UtcNow;
 
@@ -198,7 +198,7 @@ public sealed class ApimPolicyApplyService : IApimPolicyApplyService
         return new ApplyPolicyAcceptedResponse
         {
             AssignmentId = assignment.Id,
-            Status = PolicyAssignmentStatuses.Applying
+            Status = PolicyAssignmentStatuses.Pending
         };
     }
 

--- a/src/AIPolicyEngine.Api/Services/ApimManagement/TemplateLibraryService.cs
+++ b/src/AIPolicyEngine.Api/Services/ApimManagement/TemplateLibraryService.cs
@@ -154,7 +154,7 @@ public sealed class TemplateLibraryService : ITemplateLibraryService
                 }
 
                 var policyXml = await File.ReadAllTextAsync(policyPath, ct);
-                ValidateManifestAgainstPolicy(manifest, policyXml, policyPath);
+                ValidateManifestAgainstPolicy(manifest, policyXml, manifestPath);
 
                 if (templates.ContainsKey(manifest.Id))
                 {
@@ -192,11 +192,11 @@ public sealed class TemplateLibraryService : ITemplateLibraryService
             $"Unable to locate policies/templates under '{_hostEnvironment.ContentRootPath}'.");
     }
 
-    private static void ValidateManifestAgainstPolicy(TemplateManifest manifest, string policyXml, string policyPath)
+    private static void ValidateManifestAgainstPolicy(TemplateManifest manifest, string policyXml, string manifestPath)
     {
         if (string.IsNullOrWhiteSpace(manifest.Id))
         {
-            throw new InvalidOperationException($"Template manifest '{policyPath}' must declare a non-empty id.");
+            throw new InvalidOperationException($"Template manifest '{manifestPath}' must declare a non-empty id.");
         }
 
         if (string.IsNullOrWhiteSpace(manifest.DisplayName))

--- a/src/AIPolicyEngine.Api/appsettings.json
+++ b/src/AIPolicyEngine.Api/appsettings.json
@@ -7,11 +7,23 @@
   },
   "AllowedHosts": "*",
 
+  "AuthProvider": "AzureAd",
+
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "",
     "ClientId": "",
     "Audience": ""
+  },
+
+  "Keycloak": {
+    "Authority": "",
+    "Audience": "",
+    "ClientId": "",
+    "RequireHttpsMetadata": true,
+    "FrontendUrl": "",
+    "Realm": "",
+    "FrontendClientId": ""
   },
 
   "APPLICATIONINSIGHTS_CONNECTION_STRING": "",

--- a/src/AIPolicyEngine.Tests/ApimManagement/ApplyOrchestratorTests.cs
+++ b/src/AIPolicyEngine.Tests/ApimManagement/ApplyOrchestratorTests.cs
@@ -37,7 +37,7 @@ public sealed class ApplyOrchestratorTests
         await sut.ProcessAssignmentAsync("api-1", null);
 
         Assert.Equal("pa:api-1:_all", response.AssignmentId);
-        Assert.Equal(PolicyAssignmentStatuses.Applying, response.Status);
+        Assert.Equal(PolicyAssignmentStatuses.Pending, response.Status);
         Assert.Equal([PolicyAssignmentStatuses.Pending, PolicyAssignmentStatuses.Applying, PolicyAssignmentStatuses.Synced], repo.UpsertHistory.Select(x => x.Status).ToArray());
 
         var stored = await repo.GetAsync("api-1", null);

--- a/src/AIPolicyEngine.Tests/Integration/AccessProfilePrecheckTests.cs
+++ b/src/AIPolicyEngine.Tests/Integration/AccessProfilePrecheckTests.cs
@@ -160,6 +160,48 @@ public sealed class AccessProfilePrecheckTests : IClassFixture<ChargebackApiFact
     }
 
     [Fact]
+    public async Task Precheck_BlockedProfile_Returns403()
+    {
+        SeedClientAssignment(CreateLegacyAssignment(planId: "legacy-plan"));
+
+        var (resolverProxy, tracker) = CreateResolverProxy((clientAppId, tenantId, apiId, operationId) =>
+            new ResolvedAccessSnapshot(
+                PlanId: "",
+                RoutingPolicyId: null,
+                AllowedDeployments: [],
+                SourceProfileId: $"ap:{clientAppId}:{tenantId}:{apiId}:{operationId ?? "_all"}",
+                Blocked: true));
+
+        using var client = CreateClient(resolverProxy);
+        var response = await client.GetAsync($"/api/precheck/{ClientAppId}/{TenantId}?deploymentId=gpt-4o&apiId=openai-api&operationId=chat");
+        var json = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Single(tracker.Calls);
+        Assert.Equal("access-profile-blocked", json.RootElement.GetProperty("deniedBy").GetString());
+        Assert.Equal($"ap:{ClientAppId}:{TenantId}:openai-api:chat", json.RootElement.GetProperty("accessProfileId").GetString());
+    }
+
+    [Fact]
+    public async Task Precheck_BlockedProfile_Returns403_EvenWithoutClientAssignment()
+    {
+        var (resolverProxy, _) = CreateResolverProxy((clientAppId, tenantId, apiId, operationId) =>
+            new ResolvedAccessSnapshot(
+                PlanId: "",
+                RoutingPolicyId: null,
+                AllowedDeployments: [],
+                SourceProfileId: $"ap:{clientAppId}:{tenantId}:{apiId}:{operationId ?? "_all"}",
+                Blocked: true));
+
+        using var client = CreateClient(resolverProxy);
+        var response = await client.GetAsync($"/api/precheck/{ClientAppId}/{TenantId}?deploymentId=gpt-4o&apiId=openai-api");
+        var json = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("access-profile-blocked", json.RootElement.GetProperty("deniedBy").GetString());
+    }
+
+    [Fact]
     public void TemplateRendering_ApiIdVariableExtraction()
     {
         foreach (var templateId in ShippedTemplateIds)

--- a/src/AIPolicyEngine.Tests/Services/AccessProfiles/AccessProfileResolverTests.cs
+++ b/src/AIPolicyEngine.Tests/Services/AccessProfiles/AccessProfileResolverTests.cs
@@ -101,6 +101,39 @@ public sealed class AccessProfileResolverTests
         Assert.Equal($"ap:{ClientAppId}:{TenantId}:openai-api:_all", resolved.SourceProfileId);
     }
 
+    [Fact]
+    public async Task ResolveAsync_BlockedProfile_ResolvesWithBlockedFlag()
+    {
+        using var harness = CreateResolverHarness(
+        [
+            CreateAccessProfile(ClientAppId, TenantId, "openai-api", "chat", "blocked-plan", blocked: true)
+        ],
+        legacyAssignment: CreateLegacyAssignment(planId: "legacy-plan"));
+
+        var resolved = await harness.ResolveAsync(ClientAppId, TenantId, "openai-api", "chat");
+
+        Assert.NotNull(resolved);
+        Assert.True(resolved!.Blocked);
+        Assert.Equal($"ap:{ClientAppId}:{TenantId}:openai-api:chat", resolved.SourceProfileId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DisabledBlockedProfile_IsSkipped()
+    {
+        using var harness = CreateResolverHarness(
+        [
+            CreateAccessProfile(ClientAppId, TenantId, "openai-api", "chat", "blocked-plan", blocked: true, enabled: false),
+            CreateAccessProfile(ClientAppId, TenantId, "openai-api", null, "api-plan")
+        ],
+        legacyAssignment: CreateLegacyAssignment(planId: "legacy-plan"));
+
+        var resolved = await harness.ResolveAsync(ClientAppId, TenantId, "openai-api", "chat");
+
+        Assert.NotNull(resolved);
+        Assert.False(resolved!.Blocked);
+        Assert.Equal("api-plan", resolved.PlanId);
+    }
+
     private static ClientPlanAssignment CreateLegacyAssignment(string planId, string? routingPolicyId = null, List<string>? allowedDeployments = null)
         => new()
         {

--- a/src/AIPolicyEngine.Tests/Services/AccessProfiles/AccessProfileTestSupport.cs
+++ b/src/AIPolicyEngine.Tests/Services/AccessProfiles/AccessProfileTestSupport.cs
@@ -26,6 +26,7 @@ internal static class AccessProfileTestSupport
         string planId,
         string? routingPolicyId = null,
         IEnumerable<string>? allowedDeployments = null,
+        bool blocked = false,
         bool enabled = true)
     {
         var accessProfileType = RequireType("AccessProfile");
@@ -41,6 +42,7 @@ internal static class AccessProfileTestSupport
         SetProperty(accessProfile, "PlanId", planId);
         SetProperty(accessProfile, "RoutingPolicyId", routingPolicyId);
         SetProperty(accessProfile, "AllowedDeployments", (allowedDeployments ?? []).ToList());
+        SetProperty(accessProfile, "Blocked", blocked);
         SetProperty(accessProfile, "Enabled", enabled);
         SetProperty(accessProfile, "CreatedAt", new DateTime(2026, 05, 21, 12, 0, 0, DateTimeKind.Utc));
         SetProperty(accessProfile, "UpdatedAt", new DateTime(2026, 05, 21, 12, 0, 0, DateTimeKind.Utc));
@@ -116,6 +118,7 @@ internal static class AccessProfileTestSupport
         SetProperty(resolved, "RoutingPolicyId", snapshot.RoutingPolicyId);
         SetProperty(resolved, "AllowedDeployments", snapshot.AllowedDeployments.ToList());
         SetProperty(resolved, "SourceProfileId", snapshot.SourceProfileId);
+        SetProperty(resolved, "Blocked", snapshot.Blocked);
         return resolved;
     }
 
@@ -132,6 +135,9 @@ internal static class AccessProfileTestSupport
             _ => throw new XunitException($"Property '{propertyName}' is not a string list.")
         };
     }
+
+    public static bool GetBool(object? instance, string propertyName)
+        => instance is not null && GetProperty(instance, propertyName) is bool b && b;
 
     private static void RegisterConstructorDependencies(IServiceCollection services, Type implementationType, IReadOnlyList<object> accessProfiles)
     {
@@ -312,7 +318,7 @@ internal static class AccessProfileTestSupport
         => JsonSerializer.Deserialize(JsonSerializer.Serialize(instance, instance.GetType(), JsonConfig.Default), instance.GetType(), JsonConfig.Default)
            ?? throw new XunitException($"Failed to clone instance of '{instance.GetType().Name}'.");
 
-    internal sealed record ResolvedAccessSnapshot(string PlanId, string? RoutingPolicyId, IReadOnlyList<string> AllowedDeployments, string? SourceProfileId);
+    internal sealed record ResolvedAccessSnapshot(string PlanId, string? RoutingPolicyId, IReadOnlyList<string> AllowedDeployments, string? SourceProfileId, bool Blocked = false);
 
     internal sealed class ResolverInvocationTracker
     {
@@ -341,7 +347,8 @@ internal static class AccessProfileTestSupport
                 GetString(result, "PlanId") ?? throw new XunitException("Resolved access is missing PlanId."),
                 GetString(result, "RoutingPolicyId"),
                 GetStrings(result, "AllowedDeployments"),
-                GetString(result, "SourceProfileId"));
+                GetString(result, "SourceProfileId"),
+                GetBool(result, "Blocked"));
         }
 
         public void Dispose()

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /ui
 COPY aipolicyengine-ui/package*.json ./
 RUN npm ci
 COPY aipolicyengine-ui/ ./
-RUN npm run build
+RUN npm run build -- --outDir /ui/dist --emptyOutDir
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -26,4 +26,5 @@ WORKDIR /app
 EXPOSE 8080
 ENV ASPNETCORE_URLS=http://+:8080
 COPY --from=build /app/publish .
+USER $APP_UID
 ENTRYPOINT ["dotnet", "AIPolicyEngine.Api.dll"]

--- a/src/aipolicyengine-ui/.env.sample
+++ b/src/aipolicyengine-ui/.env.sample
@@ -6,3 +6,7 @@ VITE_AZURE_TENANT_ID=<tenant-id>
 VITE_AZURE_API_APP_ID=<api-app-id>
 VITE_AZURE_AUTHORITY=https://login.microsoftonline.com/<tenant-id>
 VITE_AZURE_SCOPE=api://<api-app-id>/access_as_user
+
+# Auth provider and Keycloak settings are now served at runtime from the
+# backend /api/auth-config endpoint. Configure them in the API's appsettings
+# or Kubernetes configmap instead of here.

--- a/src/aipolicyengine-ui/package-lock.json
+++ b/src/aipolicyengine-ui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aipolicy-ui",
+  "name": "aipolicyengine-ui",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aipolicy-ui",
+      "name": "aipolicyengine-ui",
       "version": "0.0.0",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.577.0",
+        "oidc-client-ts": "^3.5.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "recharts": "^3.7.0",
@@ -23,7 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@types/node": "^24.10.1",
+        "@types/node": "^24.12.4",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
@@ -1839,9 +1840,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
-      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3232,6 +3233,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3607,6 +3617,18 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/src/aipolicyengine-ui/package.json
+++ b/src/aipolicyengine-ui/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.577.0",
+    "oidc-client-ts": "^3.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "recharts": "^3.7.0",
@@ -25,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@types/node": "^24.10.1",
+    "@types/node": "^24.12.4",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/src/aipolicyengine-ui/src/App.tsx
+++ b/src/aipolicyengine-ui/src/App.tsx
@@ -13,7 +13,7 @@ import { RequestBilling } from "./pages/RequestBilling"
 import { AccessProfiles } from "./pages/AccessProfiles"
 import { Apis } from "./pages/Apis"
 import { loginRequest } from "./auth/msalConfig"
-import { fetchPlans } from "./api"
+import { getResolvedAuthProvider, getResolvedAuthConfig, fetchPlans } from "./api"
 import type { PlanData, BillingMode } from "./types"
 import { Button } from "./components/ui/button"
 import { Activity, LogIn } from "lucide-react"
@@ -38,12 +38,85 @@ function resolveTabFromPathname(pathname: string): TabId {
   return (matchingEntry?.[0] as TabId | undefined) ?? "dashboard"
 }
 
-function App() {
+function KeycloakApp() {
+  const [activeTab, setActiveTab] = useState("dashboard")
+  const [selectedClient, setSelectedClient] = useState<{ clientAppId: string; tenantId: string } | null>(null)
+  const [plans, setPlans] = useState<PlanData[]>([])
+  const authProvider = getResolvedAuthProvider()
+  const [isAuthenticated, setIsAuthenticated] = useState(authProvider?.isAuthenticated() ?? false)
+
+  useEffect(() => {
+    setIsAuthenticated(authProvider?.isAuthenticated() ?? false)
+  }, [authProvider])
+
+  const loadPlans = useCallback(async () => {
+    try {
+      const res = await fetchPlans()
+      setPlans(res.plans ?? [])
+    } catch {
+      // Plans may not be loaded yet
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isAuthenticated) loadPlans()
+  }, [isAuthenticated, loadPlans])
+
+  const billingMode: BillingMode = useMemo(() => {
+    if (plans.length === 0) return 'token'
+    const hasMultiplier = plans.some(p => p.useMultiplierBilling)
+    const hasToken = plans.some(p => !p.useMultiplierBilling)
+    if (hasMultiplier && hasToken) return 'hybrid'
+    if (hasMultiplier) return 'multiplier'
+    return 'token'
+  }, [plans])
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-6 p-8 rounded-xl border bg-card shadow-lg max-w-sm text-center">
+          <Activity className="h-12 w-12 text-blue-500" />
+          <div>
+            <h1 className="text-2xl font-bold mb-2">AI Policy Engine Dashboard</h1>
+            <p className="text-muted-foreground text-sm">Sign in with your organization account to access the dashboard.</p>
+          </div>
+          <Button onClick={() => authProvider?.login()} className="gap-2 w-full">
+            <LogIn className="h-4 w-4" />
+            Sign in with Keycloak
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (selectedClient) {
+    return (
+      <Layout activeTab={activeTab} onTabChange={(tab) => { setSelectedClient(null); setActiveTab(tab); }} billingMode={billingMode}>
+        <ClientDetail clientAppId={selectedClient.clientAppId} tenantId={selectedClient.tenantId} onBack={() => setSelectedClient(null)} />
+      </Layout>
+    )
+  }
+
+  return (
+    <Layout activeTab={activeTab} onTabChange={setActiveTab} billingMode={billingMode}>
+      {activeTab === "dashboard" && <Dashboard onSelectClient={(clientAppId, tenantId) => setSelectedClient({ clientAppId, tenantId })} />}
+      {activeTab === "clients" && <Clients onSelectClient={(clientAppId, tenantId) => setSelectedClient({ clientAppId, tenantId })} />}
+      {activeTab === "plans" && <Plans />}
+      {activeTab === "pricing" && <Pricing />}
+      {activeTab === "routing" && <RoutingPolicies />}
+      {activeTab === "requests" && <RequestBilling onSelectClient={(clientAppId, tenantId) => setSelectedClient({ clientAppId, tenantId })} />}
+      {activeTab === "export" && <Export />}
+    </Layout>
+  )
+}
+
+function AzureAdApp() {
   const [activeTab, setActiveTab] = useState<TabId>(() => resolveTabFromPathname(window.location.pathname))
   const [selectedClient, setSelectedClient] = useState<{ clientAppId: string; tenantId: string } | null>(null)
   const [plans, setPlans] = useState<PlanData[]>([])
   const isAuthenticated = useIsAuthenticated()
-  const { instance, inProgress } = useMsal()
+  const { inProgress } = useMsal()
+  const authProvider = getResolvedAuthProvider()
 
   const handleTabChange = useCallback((tab: string) => {
     const nextTab = (tab in TAB_PATHS ? tab : "dashboard") as TabId
@@ -149,6 +222,12 @@ function App() {
       {activeTab === "export" && <Export />}
     </Layout>
   )
+}
+
+function App() {
+  const config = getResolvedAuthConfig();
+  if (config?.authProvider === "Keycloak") return <KeycloakApp />;
+  return <AzureAdApp />;
 }
 
 export default App

--- a/src/aipolicyengine-ui/src/App.tsx
+++ b/src/aipolicyengine-ui/src/App.tsx
@@ -115,8 +115,7 @@ function AzureAdApp() {
   const [selectedClient, setSelectedClient] = useState<{ clientAppId: string; tenantId: string } | null>(null)
   const [plans, setPlans] = useState<PlanData[]>([])
   const isAuthenticated = useIsAuthenticated()
-  const { inProgress } = useMsal()
-  const authProvider = getResolvedAuthProvider()
+  const { instance, inProgress } = useMsal()
 
   const handleTabChange = useCallback((tab: string) => {
     const nextTab = (tab in TAB_PATHS ? tab : "dashboard") as TabId

--- a/src/aipolicyengine-ui/src/api.ts
+++ b/src/aipolicyengine-ui/src/api.ts
@@ -1,55 +1,52 @@
-import { InteractionRequiredAuthError, PublicClientApplication, type SilentRequest } from "@azure/msal-browser";
-import { msalConfig, loginRequest } from "./auth/msalConfig";
+import { initAuth, type AuthProvider, type AuthConfig } from "./auth";
 import type { ChargebackResponse, QuotasResponse, QuotaUpdateRequest, QuotaData, PlansResponse, PlanCreateRequest, PlanUpdateRequest, PlanData, ClientsResponse, ClientAssignRequest, ClientUsageResponse, ClientTracesResponse, UsageSummaryResponse, RequestLogsResponse, ModelPricingResponse, ModelPricingCreateRequest, ModelPricing, ExportPeriodsResponse, DeploymentsResponse, RoutingPoliciesResponse, ModelRoutingPolicy, ModelRoutingPolicyCreateRequest, ModelRoutingPolicyUpdateRequest, RequestSummaryResponse } from "./types";
 
 export const API_BASE = import.meta.env.VITE_API_URL || "";
 
-const msalInstance = new PublicClientApplication(msalConfig);
-let redirectInFlight = false;
+// --- Auth initialization (single promise for the whole app) ---
+let _authProvider: AuthProvider | null = null;
+let _authConfig: AuthConfig | null = null;
 
-// Initialize MSAL and handle redirect/popup responses on page load.
-// This is critical — without it, popup auth flow will hang.
-const msalReady = msalInstance.initialize().then(() => {
-  return msalInstance.handleRedirectPromise();
-});
-
-function isInteractionInProgress(): boolean {
-  return redirectInFlight || window.sessionStorage.getItem("msal.interaction.status") === "interaction_in_progress";
+/** Initialize auth — call once at app startup, before rendering. */
+export async function initializeAuth(): Promise<{ provider: AuthProvider; config: AuthConfig }> {
+  const result = await initAuth();
+  _authProvider = result.provider;
+  _authConfig = result.config;
+  return result;
 }
 
-async function startRedirectOnce(): Promise<void> {
-  if (isInteractionInProgress()) return;
-  redirectInFlight = true;
-  await msalInstance.acquireTokenRedirect(loginRequest);
+export function getResolvedAuthProvider(): AuthProvider | null {
+  return _authProvider;
+}
+
+export function getResolvedAuthConfig(): AuthConfig | null {
+  return _authConfig;
 }
 
 async function getToken(): Promise<string | null> {
-  await msalReady;
-  const accounts = msalInstance.getAllAccounts();
-  if (accounts.length === 0) return null;
-  try {
-    const request: SilentRequest = { ...loginRequest, account: accounts[0] };
-    const response = await msalInstance.acquireTokenSilent(request);
-    return response.accessToken;
-  } catch (error) {
-    // Only initiate interactive auth when MSAL explicitly requires it.
-    // Avoid re-entrant redirects that cause interaction_in_progress loops.
-    if (error instanceof InteractionRequiredAuthError) {
-      await startRedirectOnce();
-      return null;
-    }
-    if ((error as { errorCode?: string })?.errorCode === "interaction_in_progress") {
-      return null;
-    }
-    throw error;
-  } finally {
-    if (!isInteractionInProgress()) {
-      redirectInFlight = false;
-    }
-  }
+  if (!_authProvider) return null;
+  return _authProvider.getToken();
 }
 
-export async function authFetch(url: string, options: RequestInit = {}): Promise<Response> {
+/**
+ * Allowed API path prefixes — only paths starting with one of these
+ * will be permitted through to fetch, preventing SSRF.
+ */
+const ALLOWED_PATH_PREFIXES = ["/api/", "/chargeback"];
+
+/**
+ * Constructs a safe, absolute URL from a relative path by validating
+ * against the allowlist and prepending the hardcoded API_BASE.
+ */
+function buildApiUrl(path: string): string {
+  if (!ALLOWED_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    throw new Error("Request blocked: path is not in the allowed API routes.");
+  }
+  return `${API_BASE}${path}`;
+}
+
+export async function authFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const url = buildApiUrl(path);
   let token: string | null = null;
   try {
     token = await getToken();
@@ -65,6 +62,9 @@ export async function authFetch(url: string, options: RequestInit = {}): Promise
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
+  // Path is validated against ALLOWED_PATH_PREFIXES in buildApiUrl above;
+  // this is a client-side browser app — not a server — so SSRF does not apply.
+  // nosemgrep: nodejs_scan.javascript-ssrf-rule-node_ssrf
   const res = await fetch(url, { ...options, headers });
   return res;
 }
@@ -75,31 +75,31 @@ export async function parseErrorMessage(res: Response, fallback: string): Promis
 }
 
 export async function fetchUsageSummary(): Promise<UsageSummaryResponse> {
-  const res = await authFetch(`${API_BASE}/api/usage`);
+  const res = await authFetch(`/api/usage`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch usage summary"));
   return res.json();
 }
 
 export async function fetchRequestLogs(): Promise<RequestLogsResponse> {
-  const res = await authFetch(`${API_BASE}/api/logs`);
+  const res = await authFetch(`/api/logs`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch request logs"));
   return res.json();
 }
 
 export async function fetchChargeback(): Promise<ChargebackResponse> {
-  const res = await authFetch(`${API_BASE}/chargeback`);
+  const res = await authFetch(`/chargeback`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch chargeback"));
   return res.json();
 }
 
 export async function fetchQuotas(): Promise<QuotasResponse> {
-  const res = await authFetch(`${API_BASE}/api/quotas`);
+  const res = await authFetch(`/api/quotas`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch quotas"));
   return res.json();
 }
 
 export async function updateQuota(clientAppId: string, data: QuotaUpdateRequest): Promise<QuotaData> {
-  const res = await authFetch(`${API_BASE}/api/quotas/${encodeURIComponent(clientAppId)}`, {
+  const res = await authFetch(`/api/quotas/${encodeURIComponent(clientAppId)}`, {
     method: "PUT",
     body: JSON.stringify(data),
   });
@@ -108,20 +108,20 @@ export async function updateQuota(clientAppId: string, data: QuotaUpdateRequest)
 }
 
 export async function deleteQuota(clientAppId: string): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/quotas/${encodeURIComponent(clientAppId)}`, {
+  const res = await authFetch(`/api/quotas/${encodeURIComponent(clientAppId)}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to delete quota"));
 }
 
 export async function fetchPlans(): Promise<PlansResponse> {
-  const res = await authFetch(`${API_BASE}/api/plans`);
+  const res = await authFetch(`/api/plans`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch plans"));
   return res.json();
 }
 
 export async function createPlan(data: PlanCreateRequest): Promise<PlanData> {
-  const res = await authFetch(`${API_BASE}/api/plans`, {
+  const res = await authFetch(`/api/plans`, {
     method: "POST",
     body: JSON.stringify(data),
   });
@@ -130,7 +130,7 @@ export async function createPlan(data: PlanCreateRequest): Promise<PlanData> {
 }
 
 export async function updatePlan(planId: string, data: PlanUpdateRequest): Promise<unknown> {
-  const res = await authFetch(`${API_BASE}/api/plans/${encodeURIComponent(planId)}`, {
+  const res = await authFetch(`/api/plans/${encodeURIComponent(planId)}`, {
     method: "PUT",
     body: JSON.stringify(data),
   });
@@ -139,20 +139,20 @@ export async function updatePlan(planId: string, data: PlanUpdateRequest): Promi
 }
 
 export async function deletePlan(planId: string): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/plans/${encodeURIComponent(planId)}`, {
+  const res = await authFetch(`/api/plans/${encodeURIComponent(planId)}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to delete plan"));
 }
 
 export async function fetchClients(): Promise<ClientsResponse> {
-  const res = await authFetch(`${API_BASE}/api/clients`);
+  const res = await authFetch(`/api/clients`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch clients"));
   return res.json();
 }
 
 export async function assignClient(clientAppId: string, tenantId: string, data: ClientAssignRequest): Promise<unknown> {
-  const res = await authFetch(`${API_BASE}/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}`, {
+  const res = await authFetch(`/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}`, {
     method: "PUT",
     body: JSON.stringify(data),
   });
@@ -161,32 +161,32 @@ export async function assignClient(clientAppId: string, tenantId: string, data: 
 }
 
 export async function removeClient(clientAppId: string, tenantId: string): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}`, {
+  const res = await authFetch(`/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to remove client"));
 }
 
 export async function fetchClientUsage(clientAppId: string, tenantId: string): Promise<ClientUsageResponse> {
-  const res = await authFetch(`${API_BASE}/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}/usage`);
+  const res = await authFetch(`/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}/usage`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch client usage"));
   return res.json();
 }
 
 export async function fetchClientTraces(clientAppId: string, tenantId: string): Promise<ClientTracesResponse> {
-  const res = await authFetch(`${API_BASE}/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}/traces`);
+  const res = await authFetch(`/api/clients/${encodeURIComponent(clientAppId)}/${encodeURIComponent(tenantId)}/traces`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch client traces"));
   return res.json();
 }
 
 export async function fetchPricing(): Promise<ModelPricingResponse> {
-  const res = await authFetch(`${API_BASE}/api/pricing`);
+  const res = await authFetch(`/api/pricing`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch pricing"));
   return res.json();
 }
 
 export async function updatePricing(modelId: string, data: ModelPricingCreateRequest): Promise<ModelPricing> {
-  const res = await authFetch(`${API_BASE}/api/pricing/${encodeURIComponent(modelId)}`, {
+  const res = await authFetch(`/api/pricing/${encodeURIComponent(modelId)}`, {
     method: "PUT",
     body: JSON.stringify(data),
   });
@@ -195,7 +195,7 @@ export async function updatePricing(modelId: string, data: ModelPricingCreateReq
 }
 
 export async function deletePricing(modelId: string): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/pricing/${encodeURIComponent(modelId)}`, { method: "DELETE" });
+  const res = await authFetch(`/api/pricing/${encodeURIComponent(modelId)}`, { method: "DELETE" });
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to delete pricing"));
 }
 
@@ -204,25 +204,25 @@ export function exportCsvUrl(): string {
 }
 
 export async function fetchDeployments(): Promise<DeploymentsResponse> {
-  const res = await authFetch(`${API_BASE}/api/deployments`);
+  const res = await authFetch(`/api/deployments`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch deployments"));
   return res.json();
 }
 
 export async function fetchExportPeriods(): Promise<ExportPeriodsResponse> {
-  const res = await authFetch(`${API_BASE}/api/export/available-periods`);
+  const res = await authFetch(`/api/export/available-periods`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch export periods"));
   return res.json();
 }
 
 export async function downloadBillingSummary(year: number, month: number): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/export/billing-summary?year=${year}&month=${month}`);
+  const res = await authFetch(`/api/export/billing-summary?year=${year}&month=${month}`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to download billing summary"));
   await triggerBlobDownload(res);
 }
 
 export async function downloadClientAudit(clientAppId: string, tenantId: string, year: number, month: number): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/export/client-audit?clientAppId=${encodeURIComponent(clientAppId)}&tenantId=${encodeURIComponent(tenantId)}&year=${year}&month=${month}`);
+  const res = await authFetch(`/api/export/client-audit?clientAppId=${encodeURIComponent(clientAppId)}&tenantId=${encodeURIComponent(tenantId)}&year=${year}&month=${month}`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to download client audit"));
   await triggerBlobDownload(res);
 }
@@ -245,19 +245,19 @@ async function triggerBlobDownload(res: Response): Promise<void> {
 // --- Phase 4: Model Routing & Multiplier Billing API ---
 
 export async function fetchRoutingPolicies(): Promise<RoutingPoliciesResponse> {
-  const res = await authFetch(`${API_BASE}/api/routing-policies`);
+  const res = await authFetch(`/api/routing-policies`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch routing policies"));
   return res.json();
 }
 
 export async function fetchRoutingPolicy(policyId: string): Promise<ModelRoutingPolicy> {
-  const res = await authFetch(`${API_BASE}/api/routing-policies/${encodeURIComponent(policyId)}`);
+  const res = await authFetch(`/api/routing-policies/${encodeURIComponent(policyId)}`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch routing policy"));
   return res.json();
 }
 
 export async function createRoutingPolicy(data: ModelRoutingPolicyCreateRequest): Promise<ModelRoutingPolicy> {
-  const res = await authFetch(`${API_BASE}/api/routing-policies`, {
+  const res = await authFetch(`/api/routing-policies`, {
     method: "POST",
     body: JSON.stringify(data),
   });
@@ -266,7 +266,7 @@ export async function createRoutingPolicy(data: ModelRoutingPolicyCreateRequest)
 }
 
 export async function updateRoutingPolicy(policyId: string, data: ModelRoutingPolicyUpdateRequest): Promise<ModelRoutingPolicy> {
-  const res = await authFetch(`${API_BASE}/api/routing-policies/${encodeURIComponent(policyId)}`, {
+  const res = await authFetch(`/api/routing-policies/${encodeURIComponent(policyId)}`, {
     method: "PUT",
     body: JSON.stringify(data),
   });
@@ -275,7 +275,7 @@ export async function updateRoutingPolicy(policyId: string, data: ModelRoutingPo
 }
 
 export async function deleteRoutingPolicy(policyId: string): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/routing-policies/${encodeURIComponent(policyId)}`, {
+  const res = await authFetch(`/api/routing-policies/${encodeURIComponent(policyId)}`, {
     method: "DELETE",
   });
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to delete routing policy"));
@@ -286,7 +286,7 @@ export async function fetchRequestSummary(year?: number, month?: number): Promis
   if (year !== undefined) params.set("year", String(year));
   if (month !== undefined) params.set("month", String(month));
   const qs = params.toString();
-  const res = await authFetch(`${API_BASE}/api/chargeback/request-summary${qs ? `?${qs}` : ""}`);
+  const res = await authFetch(`/api/chargeback/request-summary${qs ? `?${qs}` : ""}`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to fetch request summary"));
   return res.json();
 }
@@ -296,9 +296,7 @@ export async function downloadRequestBilling(year?: number, month?: number): Pro
   if (year !== undefined) params.set("year", String(year));
   if (month !== undefined) params.set("month", String(month));
   const qs = params.toString();
-  const res = await authFetch(`${API_BASE}/api/export/request-billing${qs ? `?${qs}` : ""}`);
+  const res = await authFetch(`/api/export/request-billing${qs ? `?${qs}` : ""}`);
   if (!res.ok) throw new Error(await parseErrorMessage(res, "Failed to download request billing"));
   await triggerBlobDownload(res);
 }
-
-export { msalInstance, msalReady };

--- a/src/aipolicyengine-ui/src/auth/authProvider.ts
+++ b/src/aipolicyengine-ui/src/auth/authProvider.ts
@@ -1,0 +1,56 @@
+/**
+ * Auth provider abstraction — allows switching between MSAL (Azure AD)
+ * and OIDC (Keycloak) based on the runtime /api/auth-config endpoint.
+ */
+
+export interface AuthProvider {
+  /** Initialize the auth provider (handle redirects, etc.) */
+  initialize(): Promise<void>;
+  /** Get an access token for API calls, or null if not authenticated */
+  getToken(): Promise<string | null>;
+  /** Check if the user is currently authenticated */
+  isAuthenticated(): boolean;
+  /** Trigger interactive login */
+  login(): Promise<void>;
+  /** Trigger logout */
+  logout(): Promise<void>;
+  /** Get the display name of the current user */
+  getUserDisplayName(): string | null;
+}
+
+export type AuthProviderType = "AzureAd" | "Keycloak";
+
+export interface AuthConfig {
+  authProvider: AuthProviderType;
+  clientId: string;
+  authority: string;
+  audience: string;
+  // AzureAd-specific
+  tenantId?: string;
+  scope?: string;
+  // Keycloak-specific
+  realm?: string;
+  frontendUrl?: string;
+}
+
+const API_BASE = import.meta.env.VITE_API_URL || "";
+
+let _cachedConfig: AuthConfig | null = null;
+
+/**
+ * Fetch auth configuration from the backend at runtime.
+ * Result is cached — only one network call per page load.
+ */
+export async function fetchAuthConfig(): Promise<AuthConfig> {
+  if (_cachedConfig) return _cachedConfig;
+  const res = await fetch(`${API_BASE}/api/auth-config`);
+  if (!res.ok) {
+    throw new Error(`Failed to load auth config: ${res.statusText}`);
+  }
+  _cachedConfig = await res.json();
+  return _cachedConfig!;
+}
+
+export function getCachedAuthConfig(): AuthConfig | null {
+  return _cachedConfig;
+}

--- a/src/aipolicyengine-ui/src/auth/index.ts
+++ b/src/aipolicyengine-ui/src/auth/index.ts
@@ -1,0 +1,33 @@
+import type { AuthProvider } from "./authProvider";
+import { fetchAuthConfig, type AuthConfig } from "./authProvider";
+
+export type { AuthProvider } from "./authProvider";
+export type { AuthProviderType, AuthConfig } from "./authProvider";
+export { fetchAuthConfig, getCachedAuthConfig } from "./authProvider";
+
+let _authProvider: AuthProvider | null = null;
+let _resolvedConfig: AuthConfig | null = null;
+
+/**
+ * Fetch runtime config from the backend, then create and initialize
+ * the correct auth provider. Returns both the provider and the config.
+ */
+export async function initAuth(): Promise<{ provider: AuthProvider; config: AuthConfig }> {
+  if (_authProvider && _resolvedConfig) {
+    return { provider: _authProvider, config: _resolvedConfig };
+  }
+
+  const config = await fetchAuthConfig();
+  _resolvedConfig = config;
+
+  if (config.authProvider === "Keycloak") {
+    const { createKeycloakAuthProvider } = await import("./keycloakAuth");
+    _authProvider = createKeycloakAuthProvider(config);
+  } else {
+    const { createMsalAuthProvider } = await import("./msalAuth");
+    _authProvider = createMsalAuthProvider(config);
+  }
+
+  await _authProvider.initialize();
+  return { provider: _authProvider, config };
+}

--- a/src/aipolicyengine-ui/src/auth/keycloakAuth.ts
+++ b/src/aipolicyengine-ui/src/auth/keycloakAuth.ts
@@ -1,0 +1,80 @@
+import { UserManager, WebStorageStateStore, type User } from "oidc-client-ts";
+import type { AuthProvider, AuthConfig } from "./authProvider";
+
+let userManager: UserManager | null = null;
+let currentUser: User | null = null;
+
+export function createKeycloakAuthProvider(config: AuthConfig): AuthProvider {
+  // Build authority from components if not directly provided
+  const authority = config.authority
+    || (config.frontendUrl && config.realm ? `${config.frontendUrl}/realms/${config.realm}` : "");
+
+  userManager = new UserManager({
+    authority,
+    client_id: config.clientId,
+    redirect_uri: window.location.origin,
+    post_logout_redirect_uri: window.location.origin,
+    response_type: "code",
+    response_mode: "fragment",
+    scope: "openid profile email",
+    userStore: new WebStorageStateStore({ store: window.localStorage }),
+    automaticSilentRenew: true,
+    silent_redirect_uri: window.location.origin,
+  });
+
+  const mgr = userManager;
+
+  return {
+    async initialize(): Promise<void> {
+      // Handle callback redirect (fragment mode: params are in hash, not query string)
+      const hasCallback = window.location.hash.includes("code=") || window.location.hash.includes("state=")
+        || window.location.search.includes("code=") || window.location.search.includes("state=");
+      if (hasCallback) {
+        try {
+          currentUser = await mgr.signinRedirectCallback();
+          window.history.replaceState({}, document.title, window.location.pathname);
+        } catch {
+          currentUser = await mgr.getUser();
+        }
+      } else {
+        currentUser = await mgr.getUser();
+      }
+
+      mgr.events.addUserLoaded((user) => {
+        currentUser = user;
+      });
+      mgr.events.addUserUnloaded(() => {
+        currentUser = null;
+      });
+    },
+
+    async getToken(): Promise<string | null> {
+      if (!currentUser || currentUser.expired) {
+        try {
+          currentUser = await mgr.signinSilent();
+        } catch {
+          return null;
+        }
+      }
+      return currentUser?.access_token ?? null;
+    },
+
+    isAuthenticated(): boolean {
+      return currentUser != null && !currentUser.expired;
+    },
+
+    async login(): Promise<void> {
+      await mgr.signinRedirect();
+    },
+
+    async logout(): Promise<void> {
+      await mgr.signoutRedirect();
+    },
+
+    getUserDisplayName(): string | null {
+      return currentUser?.profile?.preferred_username
+        ?? currentUser?.profile?.name
+        ?? null;
+    },
+  };
+}

--- a/src/aipolicyengine-ui/src/auth/msalAuth.ts
+++ b/src/aipolicyengine-ui/src/auth/msalAuth.ts
@@ -1,0 +1,81 @@
+import { InteractionRequiredAuthError, PublicClientApplication, type SilentRequest } from "@azure/msal-browser";
+import type { AuthProvider, AuthConfig } from "./authProvider";
+
+let msalInstance: PublicClientApplication | null = null;
+let scopes: string[] = [];
+let redirectInFlight = false;
+
+function isInteractionInProgress(): boolean {
+  return redirectInFlight || window.sessionStorage.getItem("msal.interaction.status") === "interaction_in_progress";
+}
+
+export function createMsalAuthProvider(config: AuthConfig): AuthProvider {
+  msalInstance = new PublicClientApplication({
+    auth: {
+      clientId: config.clientId,
+      authority: config.authority,
+      redirectUri: window.location.origin,
+    },
+    cache: { cacheLocation: "localStorage" },
+  });
+
+  scopes = config.scope ? [config.scope] : [];
+
+  const instance = msalInstance;
+  const loginRequest = { scopes };
+
+  return {
+    async initialize(): Promise<void> {
+      await instance.initialize();
+      await instance.handleRedirectPromise();
+    },
+
+    async getToken(): Promise<string | null> {
+      const accounts = instance.getAllAccounts();
+      if (accounts.length === 0) return null;
+      try {
+        const request: SilentRequest = { ...loginRequest, account: accounts[0] };
+        const response = await instance.acquireTokenSilent(request);
+        return response.accessToken;
+      } catch (error) {
+        if (error instanceof InteractionRequiredAuthError) {
+          if (!isInteractionInProgress()) {
+            redirectInFlight = true;
+            await instance.acquireTokenRedirect(loginRequest);
+          }
+          return null;
+        }
+        if ((error as { errorCode?: string })?.errorCode === "interaction_in_progress") {
+          return null;
+        }
+        throw error;
+      } finally {
+        if (!isInteractionInProgress()) {
+          redirectInFlight = false;
+        }
+      }
+    },
+
+    isAuthenticated(): boolean {
+      return instance.getAllAccounts().length > 0;
+    },
+
+    async login(): Promise<void> {
+      await instance.loginRedirect(loginRequest);
+    },
+
+    async logout(): Promise<void> {
+      await instance.logoutRedirect();
+    },
+
+    getUserDisplayName(): string | null {
+      const accounts = instance.getAllAccounts();
+      return accounts.length > 0 ? accounts[0].name ?? accounts[0].username : null;
+    },
+  };
+}
+
+/** Expose the raw MSAL instance for MsalProvider (React context) */
+export function getMsalInstance(): PublicClientApplication | null {
+  return msalInstance;
+}

--- a/src/aipolicyengine-ui/src/components/accessProfiles/ProfileEditor.tsx
+++ b/src/aipolicyengine-ui/src/components/accessProfiles/ProfileEditor.tsx
@@ -12,6 +12,7 @@ export interface ProfileEditorValues {
   planId: string
   routingPolicyId: string | null
   allowedDeployments: string[]
+  blocked: boolean
   enabled: boolean
 }
 
@@ -55,6 +56,7 @@ export function ProfileEditor({
   const [planId, setPlanId] = useState(initialValues.planId)
   const [routingPolicyId, setRoutingPolicyId] = useState(initialValues.routingPolicyId ?? "")
   const [allowedDeployments, setAllowedDeployments] = useState<string[]>(initialValues.allowedDeployments)
+  const [blocked, setBlocked] = useState(initialValues.blocked)
   const [enabled, setEnabled] = useState(initialValues.enabled)
   const [deploymentQuery, setDeploymentQuery] = useState("")
   const [formError, setFormError] = useState<string | null>(null)
@@ -78,7 +80,7 @@ export function ProfileEditor({
   }
 
   const handleSave = async () => {
-    if (!planId) {
+    if (!blocked && !planId) {
       setFormError("Select a plan before saving.")
       return
     }
@@ -88,6 +90,7 @@ export function ProfileEditor({
       planId,
       routingPolicyId: routingPolicyId || null,
       allowedDeployments,
+      blocked,
       enabled,
     })
   }
@@ -132,7 +135,7 @@ export function ProfileEditor({
             </div>
           </section>
 
-          <section className="rounded-2xl border p-4">
+          <section className={cn("rounded-2xl border p-4", blocked && "opacity-50 pointer-events-none")}>
             <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">Plan + routing</h3>
             <div className="mt-4 grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
@@ -167,7 +170,7 @@ export function ProfileEditor({
             </div>
           </section>
 
-          <section className="rounded-2xl border p-4">
+          <section className={cn("rounded-2xl border p-4", blocked && "opacity-50 pointer-events-none")}>
             <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
               <div>
                 <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">Allowed deployments</h3>
@@ -230,6 +233,20 @@ export function ProfileEditor({
         <aside className="space-y-5">
           <section className="rounded-2xl border border-slate-300/70 bg-gradient-to-br from-slate-100 to-white p-4 dark:border-slate-800 dark:from-slate-900 dark:to-slate-950">
             <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">Override status</h3>
+
+            <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-3">
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 rounded border-gray-300 accent-red-600"
+                checked={blocked}
+                onChange={(event) => setBlocked(event.target.checked)}
+              />
+              <span>
+                <span className="block font-medium text-destructive">Block access</span>
+                <span className="block text-sm text-muted-foreground">Blocked profiles deny all requests at this scope with 403 Forbidden. Plan and routing settings are ignored.</span>
+              </span>
+            </label>
+
             <label className="mt-4 flex cursor-pointer items-start gap-3 rounded-xl border px-3 py-3">
               <input
                 type="checkbox"

--- a/src/aipolicyengine-ui/src/components/accessProfiles/ProfileGrid.tsx
+++ b/src/aipolicyengine-ui/src/components/accessProfiles/ProfileGrid.tsx
@@ -56,6 +56,7 @@ function sourceVariant(source: "direct" | "api" | "global" | "client"): "teal" |
 
 function directTone(profile: AccessProfile | null): string {
   if (!profile) return "border-dashed border-slate-300/70 bg-slate-500/5 dark:border-slate-700/70 dark:bg-slate-500/10"
+  if (profile.blocked) return "border-red-500/50 bg-red-500/10"
   if (!profile.enabled) return "border-amber-400/50 bg-amber-500/10"
   return "border-emerald-500/30 bg-emerald-500/10"
 }
@@ -68,6 +69,20 @@ function renderSummary(
   const effective = cell.effective
   if (!effective) {
     return <p className="text-sm text-muted-foreground">No direct or inherited profile resolves at this scope.</p>
+  }
+
+  if (effective.blocked) {
+    return (
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="destructive">Blocked</Badge>
+          <Badge variant={sourceVariant(effective.source)}>
+            {effective.source === "direct" ? "Direct override" : effective.sourceLabel}
+          </Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">All requests are denied with 403 Forbidden.</p>
+      </div>
+    )
   }
 
   const planName = plansById[effective.planId]?.name ?? effective.planId

--- a/src/aipolicyengine-ui/src/components/accessProfiles/types.ts
+++ b/src/aipolicyengine-ui/src/components/accessProfiles/types.ts
@@ -20,6 +20,7 @@ export interface EffectiveAccessPreview {
   planId: string
   routingPolicyId: string | null
   allowedDeployments: string[]
+  blocked: boolean
   enabled: boolean
 }
 

--- a/src/aipolicyengine-ui/src/components/apis/AssignTemplateForm.tsx
+++ b/src/aipolicyengine-ui/src/components/apis/AssignTemplateForm.tsx
@@ -12,7 +12,7 @@ interface AssignTemplateFormProps {
   templates: ApimTemplateSummary[]
   initialTemplateId?: string
   initialParameters?: Record<string, string | number | null>
-  planDefaults?: Record<string, string | number>
+  parameterDefaults?: Record<string, string | number>
   submitting: boolean
   onSubmit: (payload: { templateId: string; parameters: Record<string, string | number> }) => Promise<void>
 }
@@ -25,14 +25,14 @@ function toInputValue(value: string | number | null | undefined): string {
 function buildInitialValues(
   template: ApimTemplateSummary,
   initialParameters: Record<string, string | number | null> | undefined,
-  planDefaults: Record<string, string | number> | undefined,
+  parameterDefaults: Record<string, string | number> | undefined,
 ): Record<string, string> {
   return Object.fromEntries(
     template.parameters.map((parameter) => {
       const existingValue = initialParameters?.[parameter.name]
-      const planValue = planDefaults?.[parameter.name]
+      const defaultValue = parameterDefaults?.[parameter.name]
       const fallbackValue = parameter.default
-      return [parameter.name, toInputValue(existingValue ?? planValue ?? fallbackValue)]
+      return [parameter.name, toInputValue(existingValue ?? defaultValue ?? fallbackValue)]
     }),
   )
 }
@@ -49,7 +49,7 @@ export function AssignTemplateForm({
   templates,
   initialTemplateId,
   initialParameters,
-  planDefaults,
+  parameterDefaults,
   submitting,
   onSubmit,
 }: AssignTemplateFormProps) {
@@ -83,14 +83,14 @@ export function AssignTemplateForm({
       setSelectedTemplateId(preferredTemplateId)
 
       const template = filteredTemplates.find((item) => item.id === preferredTemplateId)
-      setParameterValues(template ? buildInitialValues(template, initialParameters, planDefaults) : {})
+      setParameterValues(template ? buildInitialValues(template, initialParameters, parameterDefaults) : {})
       setFormError(null)
     })
 
     return () => {
       cancelled = true
     }
-  }, [filteredTemplates, initialParameters, initialTemplateId, open, planDefaults])
+  }, [filteredTemplates, initialParameters, initialTemplateId, open, parameterDefaults])
 
   const missingRequiredFields = useMemo(() => {
     if (!selectedTemplate) return []
@@ -104,7 +104,7 @@ export function AssignTemplateForm({
     setSelectedTemplateId(templateId)
     setFormError(null)
     const template = filteredTemplates.find((item) => item.id === templateId)
-    setParameterValues(template ? buildInitialValues(template, initialParameters, planDefaults) : {})
+    setParameterValues(template ? buildInitialValues(template, initialParameters, parameterDefaults) : {})
   }
 
   const handleApply = async () => {
@@ -173,11 +173,11 @@ export function AssignTemplateForm({
           ) : selectedTemplate.parameters.length === 0 ? (
             <p className="mt-3 text-sm text-muted-foreground">This template does not require parameters.</p>
           ) : (
-            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <div className="mt-4 space-y-4">
               {selectedTemplate.parameters.map((parameter) => (
                 <div key={parameter.name} className="min-w-0 space-y-2 rounded-lg border p-3">
                   <div className="flex items-center gap-2">
-                    <label htmlFor={`template-parameter-${parameter.name}`} className="min-w-0 flex-1 truncate text-sm font-medium">
+                    <label htmlFor={`template-parameter-${parameter.name}`} className="min-w-0 flex-1 text-sm font-medium">
                       {parameter.name}
                     </label>
                     {parameter.required && <Badge variant="red" className="flex-shrink-0">Required</Badge>}
@@ -201,8 +201,8 @@ export function AssignTemplateForm({
                   {parameter.default !== undefined && parameter.default !== null && (
                     <p className="text-xs text-muted-foreground">Default: {String(parameter.default)}</p>
                   )}
-                  {planDefaults?.[parameter.name] !== undefined && (
-                    <p className="text-xs text-muted-foreground">Plan default: {String(planDefaults[parameter.name])}</p>
+                  {parameterDefaults?.[parameter.name] !== undefined && (
+                    <p className="text-xs text-muted-foreground">Default: {String(parameterDefaults[parameter.name])}</p>
                   )}
                 </div>
               ))}

--- a/src/aipolicyengine-ui/src/main.tsx
+++ b/src/aipolicyengine-ui/src/main.tsx
@@ -2,19 +2,40 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { MsalProvider } from '@azure/msal-react'
 import { ThemeProvider } from './context/ThemeProvider'
-import { msalInstance, msalReady } from './api'
+import { initializeAuth } from './api'
 import './index.css'
 import App from './App.tsx'
 
-// Wait for MSAL to initialize and handle any auth redirects before rendering
-msalReady.then(() => {
-  createRoot(document.getElementById('root')!).render(
+// Fetch runtime auth config from the backend, then initialize the correct
+// auth provider before rendering the React tree.
+initializeAuth().then(({ config }) => {
+  const app = (
     <StrictMode>
-      <MsalProvider instance={msalInstance}>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </MsalProvider>
-    </StrictMode>,
-  )
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </StrictMode>
+  );
+
+  if (config.authProvider === "AzureAd") {
+    // Lazy import to avoid loading MSAL when using Keycloak
+    import('./auth/msalAuth').then(({ getMsalInstance }) => {
+      const msalInstance = getMsalInstance();
+      if (msalInstance) {
+        createRoot(document.getElementById('root')!).render(
+          <StrictMode>
+            <MsalProvider instance={msalInstance}>
+              <ThemeProvider>
+                <App />
+              </ThemeProvider>
+            </MsalProvider>
+          </StrictMode>
+        );
+      } else {
+        createRoot(document.getElementById('root')!).render(app);
+      }
+    });
+  } else {
+    createRoot(document.getElementById('root')!).render(app);
+  }
 })

--- a/src/aipolicyengine-ui/src/pages/AccessProfiles.tsx
+++ b/src/aipolicyengine-ui/src/pages/AccessProfiles.tsx
@@ -54,6 +54,7 @@ function buildInitialValues(profile: AccessProfile | null, effective: EffectiveA
       planId: profile.planId,
       routingPolicyId: profile.routingPolicyId,
       allowedDeployments: profile.allowedDeployments,
+      blocked: profile.blocked,
       enabled: profile.enabled,
     }
   }
@@ -62,6 +63,7 @@ function buildInitialValues(profile: AccessProfile | null, effective: EffectiveA
     planId: effective?.planId ?? "",
     routingPolicyId: effective?.routingPolicyId ?? null,
     allowedDeployments: effective?.allowedDeployments ?? [],
+    blocked: effective?.blocked ?? false,
     enabled: effective?.enabled ?? true,
   }
 }
@@ -75,20 +77,23 @@ function createDirectPreview(
   return {
     source: "direct",
     sourceLabel: "Direct override",
-    sourceDescription: profile.enabled
-      ? "This scope has its own Access Profile."
-      : "This scope has a stored override, but it is disabled and no longer wins in the cascade.",
+    sourceDescription: profile.blocked
+      ? "This scope is blocked — all requests are denied with 403 Forbidden."
+      : profile.enabled
+        ? "This scope has its own Access Profile."
+        : "This scope has a stored override, but it is disabled and no longer wins in the cascade.",
     profileId: profile.id,
     planId: profile.planId,
     routingPolicyId: profile.routingPolicyId ?? plan?.modelRoutingPolicyId ?? null,
     allowedDeployments: profile.allowedDeployments.length > 0 ? profile.allowedDeployments : (plan?.allowedDeployments ?? []),
+    blocked: profile.blocked,
     enabled: profile.enabled,
   }
 }
 
 function createInheritedPreview(
   source: "api" | "global" | "client",
-  payload: { id?: string | null; planId: string; routingPolicyId: string | null; allowedDeployments: string[] },
+  payload: { id?: string | null; planId: string; routingPolicyId: string | null; allowedDeployments: string[]; blocked?: boolean },
   plansById: Record<string, PlanData>,
 ): EffectiveAccessPreview {
   const plan = plansById[payload.planId]
@@ -97,15 +102,18 @@ function createInheritedPreview(
     source,
     sourceLabel: source === "api" ? "API-wide" : source === "global" ? "Client-global" : "Client assignment",
     sourceDescription:
-      source === "api"
-        ? "Inherited from the API-wide override for this client."
-        : source === "global"
-          ? "Inherited from the client-global default for this client."
-          : "Falling back to the client's base plan assignment.",
+      payload.blocked
+        ? "Inherited block — all requests are denied at this scope."
+        : source === "api"
+          ? "Inherited from the API-wide override for this client."
+          : source === "global"
+            ? "Inherited from the client-global default for this client."
+            : "Falling back to the client's base plan assignment.",
     profileId: payload.id ?? null,
     planId: payload.planId,
     routingPolicyId: payload.routingPolicyId ?? plan?.modelRoutingPolicyId ?? null,
     allowedDeployments: payload.allowedDeployments.length > 0 ? payload.allowedDeployments : (plan?.allowedDeployments ?? []),
+    blocked: payload.blocked ?? false,
     enabled: true,
   }
 }
@@ -458,9 +466,10 @@ export function AccessProfiles() {
             tenantId: selectedClient.tenantId,
             apiId: target.apiId,
             operationId: target.operationId,
-            planId: values.planId,
+            planId: values.planId || undefined,
             routingPolicyId: values.routingPolicyId,
             allowedDeployments: values.allowedDeployments,
+            blocked: values.blocked,
             enabled: values.enabled,
           })),
         }
@@ -474,7 +483,11 @@ export function AccessProfiles() {
         }
         setQueuedScopeKeys([])
       } else if (editorState.existingProfile) {
-        await updateAccessProfile(editorState.existingProfile.id, values)
+        await updateAccessProfile(editorState.existingProfile.id, {
+          ...values,
+          routingPolicyId: values.routingPolicyId,
+          planId: values.planId || undefined,
+        })
         showToast("Access Profile updated.")
       } else {
         const target = editorState.targets[0]
@@ -483,9 +496,10 @@ export function AccessProfiles() {
           tenantId: selectedClient.tenantId,
           apiId: target.apiId,
           operationId: target.operationId,
-          planId: values.planId,
+          planId: values.planId || undefined,
           routingPolicyId: values.routingPolicyId,
           allowedDeployments: values.allowedDeployments,
+          blocked: values.blocked,
           enabled: values.enabled,
         })
         showToast("Access Profile created.")

--- a/src/aipolicyengine-ui/src/pages/Apis.tsx
+++ b/src/aipolicyengine-ui/src/pages/Apis.tsx
@@ -6,7 +6,7 @@ import { AssignTemplateForm } from "../components/apis/AssignTemplateForm"
 import { PolicyAssignmentPanel } from "../components/apis/PolicyAssignmentPanel"
 import { Badge } from "../components/ui/badge"
 import { Button } from "../components/ui/button"
-import { fetchPlans } from "../api"
+import { API_BASE, fetchPlans } from "../api"
 import {
   applyApiPolicy,
   applyOperationPolicy,
@@ -143,6 +143,22 @@ function derivePlanDefaults(plans: PlanData[]): Record<string, number> {
   return defaults
 }
 
+function deriveEnvironmentDefaults(): Record<string, string> {
+  const defaults: Record<string, string> = {}
+
+  const apiAppId = import.meta.env.VITE_AZURE_API_APP_ID
+  if (apiAppId) {
+    defaults.ContainerAppAudience = `api://${apiAppId}`
+  }
+
+  const containerAppUrl = (API_BASE || window.location.origin).replace(/\/$/, "")
+  if (containerAppUrl) {
+    defaults.ContainerAppUrl = containerAppUrl
+  }
+
+  return defaults
+}
+
 export function Apis() {
   const { accounts } = useMsal()
   const [templates, setTemplates] = useState<ApimTemplateSummary[]>([])
@@ -187,6 +203,11 @@ export function Apis() {
   const selectedKey = selectedTarget ? targetKey(selectedTarget) : undefined
   const busy = submittingAssignment || clearingAssignment
   const planDefaults = useMemo(() => derivePlanDefaults(plans), [plans])
+  const environmentDefaults = useMemo(() => deriveEnvironmentDefaults(), [])
+  const parameterDefaults = useMemo<Record<string, string | number>>(
+    () => ({ ...environmentDefaults, ...planDefaults }),
+    [environmentDefaults, planDefaults],
+  )
   const pageLoading = initialLoading || catalogLoading
   const pageError = initialError ?? catalogError
 
@@ -458,7 +479,7 @@ export function Apis() {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          {Object.keys(planDefaults).length > 0 && <Badge variant="blue">Plan defaults available</Badge>}
+          {Object.keys(parameterDefaults).length > 0 && <Badge variant="blue">Defaults available</Badge>}
           <Button type="button" variant="outline" onClick={() => void loadInitialData()} disabled={pageLoading}>
             <RefreshCcw className={`h-4 w-4 ${pageLoading ? "animate-spin" : ""}`} />
             Refresh
@@ -527,7 +548,7 @@ export function Apis() {
           templates={templates}
           initialTemplateId={policyDocument?.assignment?.templateId}
           initialParameters={policyDocument?.assignment?.parameters}
-          planDefaults={planDefaults}
+          parameterDefaults={parameterDefaults}
           submitting={submittingAssignment}
           onSubmit={handleApplyTemplate}
         />

--- a/src/aipolicyengine-ui/src/types/accessProfiles.ts
+++ b/src/aipolicyengine-ui/src/types/accessProfiles.ts
@@ -8,6 +8,7 @@ export interface AccessProfile {
   planId: string
   routingPolicyId: string | null
   allowedDeployments: string[]
+  blocked: boolean
   enabled: boolean
   createdBy: string
   createdAt: string
@@ -19,9 +20,10 @@ export interface AccessProfileCreateRequest {
   tenantId: string
   apiId: string
   operationId?: string | null
-  planId: string
+  planId?: string
   routingPolicyId?: string | null
   allowedDeployments?: string[]
+  blocked?: boolean
   enabled?: boolean
 }
 
@@ -29,6 +31,7 @@ export interface AccessProfileUpdateRequest {
   planId?: string
   routingPolicyId?: string | null
   allowedDeployments?: string[]
+  blocked?: boolean
   enabled?: boolean
 }
 


### PR DESCRIPTION
## Summary

This branch adds several features and fixes on top of main:

- **Client blocking for access profiles** — adds a \Blocked\ flag to access profiles enabling blanket-deny (403) for specific client/endpoint combinations
- **Keycloak auth option & SAST security fixes** — integrates Keycloak as an alternative auth provider alongside Azure AD, plus SSRF-safe API client (\uildApiUrl\ with path prefix allowlist)
- **Double \pi://\ prefix fix** — prevents \AuthConfigEndpoints\ from prepending \pi://\ when the audience already has it
- **PR review fixes** — null parameter coalescing, status mismatch fix, variable rename, ResourceId whitespace trim

### Commits
- \d60619b3\ feat: add client blocking to access profiles
- \92a3ced8\ feat: add keycloak auth option and sast security scan fixes
- \b5e680a\ fix: prevent double api:// prefix in auth-config scope endpoint
- \d8183b8b\ fix: address PR review comments on APIM management services

### Testing
- All 324 backend tests pass (320 passed, 4 skipped Purview tests)
- Frontend builds and lints cleanly
