### PR TITLE
fix: use relative paths in accessProfiles and apim API clients

### DIFF
--- a/src/aipolicyengine-ui/src/api/accessProfiles.ts
+++ b/src/aipolicyengine-ui/src/api/accessProfiles.ts
@@ -1,4 +1,4 @@
-import { API_BASE, authFetch, parseErrorMessage } from "../api"
+import { authFetch, parseErrorMessage } from "../api"
 import type { HttpError } from "../types/apim"
 import type {
   AccessProfile,
@@ -18,7 +18,7 @@ async function buildHttpError(res: Response, fallback: string): Promise<HttpErro
 }
 
 async function requestJson<T>(path: string, fallback: string, options: RequestInit = {}): Promise<T> {
-  const res = await authFetch(`${API_BASE}${path}`, options)
+  const res = await authFetch(path, options)
   if (!res.ok) {
     throw await buildHttpError(res, fallback)
   }
@@ -64,7 +64,7 @@ export function updateAccessProfile(profileId: string, data: AccessProfileUpdate
 }
 
 export async function deleteAccessProfile(profileId: string): Promise<void> {
-  const res = await authFetch(`${API_BASE}/api/access-profiles/${encodeURIComponent(profileId)}`, {
+  const res = await authFetch(`/api/access-profiles/${encodeURIComponent(profileId)}`, {
     method: "DELETE",
   })
 

--- a/src/aipolicyengine-ui/src/api/apim.ts
+++ b/src/aipolicyengine-ui/src/api/apim.ts
@@ -1,4 +1,4 @@
-import { API_BASE, authFetch, parseErrorMessage } from "../api.ts"
+import { authFetch, parseErrorMessage } from "../api.ts"
 import type {
   ApisResponse,
   ApiOperationsResponse,
@@ -27,7 +27,7 @@ async function buildHttpError(res: Response, fallback: string): Promise<HttpErro
 }
 
 async function requestJson<T>(path: string, fallback: string, options: RequestInit = {}): Promise<T> {
-  const res = await authFetch(`${API_BASE}${path}`, options)
+  const res = await authFetch(path, options)
   if (!res.ok) {
     throw await buildHttpError(res, fallback)
   }


### PR DESCRIPTION
Both modules were prepending API_BASE before calling authFetch, but authFetch now expects relative paths (buildApiUrl adds API_BASE). This caused 'Request blocked: path is not in the allowed API routes.
This pull request updates the API utility functions to remove the use of the `API_BASE` constant when constructing request URLs. Instead, API calls now expect fully resolved paths to be passed in, simplifying how endpoints are specified and potentially improving flexibility.

**API URL handling simplification:**

* Removed the import and usage of `API_BASE` from both `accessProfiles.ts` and `apim.ts`, so API requests now use the path provided directly rather than prefixing with a base URL. [[1]](diffhunk://#diff-db463c4d1ef0bf74cb7c7f166b3d5564616b0063ae08be689d0af3bbb8a4e4a6L1-R1) [[2]](diffhunk://#diff-3bb2e2b9bc8ec17fb577db3adff2209945c36efdc453101ca5f408c96eaf92b3L1-R1)
* Updated the `requestJson` function in both `accessProfiles.ts` and `apim.ts` to call `authFetch` with the direct `path` argument, instead of concatenating with `API_BASE`. [[1]](diffhunk://#diff-db463c4d1ef0bf74cb7c7f166b3d5564616b0063ae08be689d0af3bbb8a4e4a6L21-R21) [[2]](diffhunk://#diff-3bb2e2b9bc8ec17fb577db3adff2209945c36efdc453101ca5f408c96eaf92b3L30-R30)
* Changed the `deleteAccessProfile` function in `accessProfiles.ts` to use a direct path for the API endpoint, removing the `API_BASE` prefix.'