### PR TITLE
Omit registry URLs from npm lockfiles

### DIFF
--- a/src/aipolicyengine-ui/.npmrc
+++ b/src/aipolicyengine-ui/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/src/aipolicyengine-ui/package-lock.json
+++ b/src/aipolicyengine-ui/package-lock.json
@@ -37,7 +37,6 @@
     },
     "node_modules/@azure/msal-browser": {
       "version": "5.17.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.3.tgz",
       "integrity": "sha512-qMabD7Xrm/UgRhs+/IVyCTZRjUl8Qb+uGsRrCkaKNWsiTwRaeyStJbChE7/ySNTNYtiWo7khfF7vUDd0wGMnLw==",
       "license": "MIT",
       "dependencies": {
@@ -49,7 +48,6 @@
     },
     "node_modules/@azure/msal-common": {
       "version": "16.11.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.3.tgz",
       "integrity": "sha512-VeXOW+t3Rdd9XGX6lVyIg3DhtjMR1JD8ARKcsnGbJFUWwAmF3sHL7GwZc/ZjEUfHESResAonETRYCuG06OBT7A==",
       "license": "MIT",
       "engines": {
@@ -58,7 +56,6 @@
     },
     "node_modules/@azure/msal-react": {
       "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.4.tgz",
       "integrity": "sha512-/LbFigWLD0NUkWHr3ZZogvRGZNKlsiYDaHo2zLANU4u/7yO/TKDFunKx8M1m8fSRS0pXS5M6me7NEqDlOE8FyA==",
       "license": "MIT",
       "engines": {
@@ -71,7 +68,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
@@ -86,7 +82,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
@@ -96,7 +91,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
@@ -127,7 +121,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha1-zKC4gn5rzzuhdniOfzsYCtbbL6M=",
       "dev": true,
       "license": "MIT",
@@ -144,7 +137,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
@@ -161,7 +153,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
@@ -171,7 +162,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
@@ -185,7 +175,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
@@ -203,7 +192,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -213,7 +201,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -223,7 +210,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
@@ -233,7 +219,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
@@ -247,7 +232,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
       "dev": true,
       "license": "MIT",
@@ -263,7 +247,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
@@ -278,7 +261,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha1-xHsHpBuV2gkH0Ca13YlNmN59Ly0=",
       "dev": true,
       "license": "MIT",
@@ -297,7 +279,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
       "dev": true,
       "license": "MIT",
@@ -311,7 +292,6 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.2.tgz",
       "integrity": "sha1-+rCg88SS0R9amskGXQ1zlV7hwck=",
       "license": "MIT",
       "optional": true,
@@ -322,7 +302,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.2.tgz",
       "integrity": "sha1-6yLwTXb+v99Ph/2v9UyKU/a/Db0=",
       "license": "MIT",
       "optional": true,
@@ -332,7 +311,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "license": "MIT",
       "optional": true,
@@ -342,7 +320,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "dev": true,
       "license": "MIT",
@@ -361,7 +338,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
       "dev": true,
       "license": "Apache-2.0",
@@ -374,7 +350,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha1-vM32Fbz3tujbgw7AuNIcmiXeWXs=",
       "dev": true,
       "license": "MIT",
@@ -384,7 +359,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-array/-/config-array-0.23.5.tgz",
       "integrity": "sha1-VuhtJDBJGV2KzAwGobPf3D+j3pU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -399,7 +373,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
       "integrity": "sha1-75o2iB0539Xb6sIrDamX+r+wiwM=",
       "dev": true,
       "license": "Apache-2.0",
@@ -412,7 +385,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/core/-/core-1.2.1.tgz",
       "integrity": "sha1-wdp80bgvqHh/mLVin7gRhIobY84=",
       "dev": true,
       "license": "Apache-2.0",
@@ -425,7 +397,6 @@
     },
     "node_modules/@eslint/js": {
       "version": "10.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/js/-/js-10.0.1.tgz",
       "integrity": "sha1-HoqHb1ARevirZ+R9WtlNONZiJYM=",
       "dev": true,
       "license": "MIT",
@@ -446,7 +417,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/object-schema/-/object-schema-3.0.5.tgz",
       "integrity": "sha1-iOm/TRHSsZwILnjr586IckpesJE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -456,7 +426,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
       "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -470,7 +439,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@humanfs/core/-/core-0.19.2.tgz",
       "integrity": "sha1-qCcsoDsqz0kmcCIrIyC2xCG/3mA=",
       "dev": true,
       "license": "Apache-2.0",
@@ -483,7 +451,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@humanfs/node/-/node-0.16.8.tgz",
       "integrity": "sha1-j4AMzME/T4zTEW4tnAqUk52j4+0=",
       "dev": true,
       "license": "Apache-2.0",
@@ -498,7 +465,6 @@
     },
     "node_modules/@humanfs/types": {
       "version": "0.15.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@humanfs/types/-/types-0.15.0.tgz",
       "integrity": "sha1-8qCfYgEjkLK/8/xvskjd7IwJoJA=",
       "dev": true,
       "license": "Apache-2.0",
@@ -508,7 +474,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
       "dev": true,
       "license": "Apache-2.0",
@@ -522,7 +487,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha1-wrnS43TuYsWG062+qHGZsdenpro=",
       "dev": true,
       "license": "Apache-2.0",
@@ -536,7 +500,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "license": "MIT",
       "dependencies": {
@@ -546,7 +509,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
       "license": "MIT",
       "dependencies": {
@@ -556,7 +518,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "license": "MIT",
       "engines": {
@@ -565,13 +526,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "license": "MIT",
       "dependencies": {
@@ -581,7 +540,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
       "license": "MIT",
       "optional": true,
@@ -599,7 +557,6 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha1-ONdrnb+TTCoCvhdPsyzuvxgv50I=",
       "license": "MIT",
       "funding": {
@@ -608,7 +565,6 @@
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
       "integrity": "sha1-5ieHUDo4Vh4Eu4854pyo22iVkPk=",
       "license": "MIT",
       "dependencies": {
@@ -634,7 +590,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
       "integrity": "sha1-9Yy5oKgSjtBYIoJyBShUf8XANfM=",
       "cpu": [
         "arm64"
@@ -650,7 +605,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
       "integrity": "sha1-RBFEwFpKgxqnUmmrw6SjJDdOpwc=",
       "cpu": [
         "arm64"
@@ -666,7 +620,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
       "integrity": "sha1-yC4wZSzvUsSvkl1cZsiVWkAxmBY=",
       "cpu": [
         "x64"
@@ -682,7 +635,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
       "integrity": "sha1-wy6c5/ocD7K4CROio6BcPpB9BrA=",
       "cpu": [
         "x64"
@@ -698,7 +650,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
       "integrity": "sha1-zpC14iMWretQLqAQWC9JjNBgTyc=",
       "cpu": [
         "arm"
@@ -714,7 +665,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
       "integrity": "sha1-kZRxEMTdqk7vsATlJogHCXcIUgE=",
       "cpu": [
         "arm64"
@@ -733,7 +683,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
       "integrity": "sha1-6zKy1BCMHHArkejN6KBD6uXKqU0=",
       "cpu": [
         "arm64"
@@ -752,7 +701,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
       "integrity": "sha1-zLlDwR5acmVcuwL8EWNUHOtkB4I=",
       "cpu": [
         "ppc64"
@@ -771,7 +719,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
       "integrity": "sha1-ozcx7lZ+kLdfrG5eVTB+iiswOPA=",
       "cpu": [
         "s390x"
@@ -790,7 +737,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
       "integrity": "sha1-p0wBqqzt/BHDm2/rozpfoMZUlJ8=",
       "cpu": [
         "x64"
@@ -809,7 +755,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
       "integrity": "sha1-KM0XhJT6HmXbpBIim1zlXE3Vy9E=",
       "cpu": [
         "x64"
@@ -828,7 +773,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
       "integrity": "sha1-98dfqRP8IIhNJqfUiNT1xZfNccA=",
       "cpu": [
         "arm64"
@@ -844,7 +788,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
       "integrity": "sha1-w3lYGUd4cIHfNj6hBhQPzV/sJS0=",
       "cpu": [
         "wasm32"
@@ -862,7 +805,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "license": "MIT",
       "optional": true,
@@ -873,7 +815,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "license": "MIT",
       "optional": true,
@@ -883,7 +824,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
       "integrity": "sha1-8jyIaU96cpoS85UCSu4434Cha6M=",
       "cpu": [
         "arm64"
@@ -899,7 +839,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
       "integrity": "sha1-M3fI3g5WqIV/ESF1YRRwkOh0y0Y=",
       "cpu": [
         "x64"
@@ -915,25 +854,21 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha1-p5tV26+GBIEvUtFAssmrQbwVC7g=",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha1-PV5gjxbCOQwQUo6Y5Zrva/c8rns=",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/node/-/node-4.3.3.tgz",
       "integrity": "sha1-OP8EMJ/wNuo1iae62QacROydOIM=",
       "license": "MIT",
       "dependencies": {
@@ -948,7 +883,6 @@
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
       "integrity": "sha1-YmYQnQJc/LBPjkxYlUpvYwpBW38=",
       "license": "MIT",
       "engines": {
@@ -971,7 +905,6 @@
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
       "integrity": "sha1-hI+TA0FV2veJIYUCjfsYFDv8fQc=",
       "cpu": [
         "arm64"
@@ -987,7 +920,6 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
       "integrity": "sha1-XHeeMsHDYb63UTb9jixif8uaWyg=",
       "cpu": [
         "arm64"
@@ -1003,7 +935,6 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
       "integrity": "sha1-uikv9S+jJkE59/54dHGc4KRmaHU=",
       "cpu": [
         "x64"
@@ -1019,7 +950,6 @@
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
       "integrity": "sha1-B+WJSHuaY2I1pK3kjO/B+e7uxX8=",
       "cpu": [
         "x64"
@@ -1035,7 +965,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
       "integrity": "sha1-DIq8Io2eGeAGXdtwfrpS4hhVs/8=",
       "cpu": [
         "arm"
@@ -1051,7 +980,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
       "integrity": "sha1-UGfcev0V0rl63HepEXfcS+yNG4s=",
       "cpu": [
         "arm64"
@@ -1067,7 +995,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
       "integrity": "sha1-Ka5fJ5vizmTbNocRmFtq2ORWLlc=",
       "cpu": [
         "arm64"
@@ -1083,7 +1010,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
       "integrity": "sha1-fWk7QPaYdXRLSZSBNZsif9OsOjw=",
       "cpu": [
         "x64"
@@ -1099,7 +1025,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
       "integrity": "sha1-alXWZPR8X/mtP0a/Bf4H1BC4z9g=",
       "cpu": [
         "x64"
@@ -1115,7 +1040,6 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
       "integrity": "sha1-QIqbxiDmjxqvDf6jPae9O2X54u8=",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
@@ -1185,7 +1109,6 @@
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
       "integrity": "sha1-PVgrABgPpGgOC2yQvmn6X0ogkJI=",
       "cpu": [
         "arm64"
@@ -1201,7 +1124,6 @@
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
       "integrity": "sha1-zkxmP+87T95nYRpME5GGb4wKp5s=",
       "cpu": [
         "x64"
@@ -1217,7 +1139,6 @@
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/vite/-/vite-4.3.3.tgz",
       "integrity": "sha1-H0A3uty15sa7V009igFyyD8muX8=",
       "license": "MIT",
       "dependencies": {
@@ -1231,7 +1152,6 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "license": "MIT",
       "optional": true,
@@ -1241,7 +1161,6 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha1-jpzZ4cNYH6azQaWu1ViOsoW+C0o=",
       "dev": true,
       "license": "MIT",
@@ -1252,25 +1171,21 @@
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha1-4CFRRk0C1KG0RkbQ/NuT+viP3ow=",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha1-NoyWGhjech2oIA6AvzlD+1MTavI=",
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha1-4o2xv7+mFwdvd3DdHZpI6qO2xRs=",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha1-QSuQ6EhwKF8v+KhGxutgNE8SpBw=",
       "license": "MIT",
       "dependencies": {
@@ -1279,13 +1194,11 @@
     },
     "node_modules/@types/d3-path": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha1-9jKzgMOsoduo40qgSbzWpK8j34o=",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha1-V6L3ByQub+Hega17/Myq9gYXmvs=",
       "license": "MIT",
       "dependencies": {
@@ -1294,7 +1207,6 @@
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha1-0VFsxQh1O+BoUs0GdY47tUoisOM=",
       "license": "MIT",
       "dependencies": {
@@ -1303,47 +1215,40 @@
     },
     "node_modules/@types/d3-time": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha1-hHL+7NY5aRRQ3YAA6zPt1EThMj8=",
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha1-cLvad9wjqnJ0E+IuIUr6Pw6FL3A=",
       "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha1-M0MRlx06BxIefrkbaEpgXn7qnL0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha1-b2Nq+WL75hkbgwvWdrpZhpJrzOw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha1-utdY1gHpfWz0V9IE7najX8570Rk=",
       "devOptional": true,
       "license": "MIT",
@@ -1353,7 +1258,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
@@ -1363,7 +1267,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
@@ -1373,13 +1276,11 @@
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha1-YL6NIbqrjDBRMuucuRLtSXhSqtw=",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
       "integrity": "sha1-Cljfb+qMC/azlvUYB3CZvIt2K7U=",
       "dev": true,
       "license": "MIT",
@@ -1408,7 +1309,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-7.0.6.tgz",
       "integrity": "sha1-aleq70yQ3yesNZCHXSno8RmIyI4=",
       "dev": true,
       "license": "MIT",
@@ -1418,7 +1318,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/parser/-/parser-8.65.0.tgz",
       "integrity": "sha1-UpXBBYwKHddG7yi6r5wDQdvfA9w=",
       "dev": true,
       "license": "MIT",
@@ -1443,7 +1342,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
       "integrity": "sha1-Zfu8mhWRq/+uq1UTIA+EgnHLCqU=",
       "dev": true,
       "license": "MIT",
@@ -1465,7 +1363,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
       "integrity": "sha1-lUcgLOfmCOe2KD31hXA7mAoOpw0=",
       "dev": true,
       "license": "MIT",
@@ -1483,7 +1380,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
       "integrity": "sha1-NvFo/NuxKV90Rv8DeWZ/mMPPG/M=",
       "dev": true,
       "license": "MIT",
@@ -1500,7 +1396,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
       "integrity": "sha1-0xbXUi2Tz/TNFPMF4C898tgE+cE=",
       "dev": true,
       "license": "MIT",
@@ -1525,7 +1420,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/types/-/types-8.65.0.tgz",
       "integrity": "sha1-PoZzhBand8i4klq0Z0X0js+QTJ8=",
       "dev": true,
       "license": "MIT",
@@ -1539,7 +1433,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
       "integrity": "sha1-8fUUgI9qpxPi1niuj/WSpl4WMq8=",
       "dev": true,
       "license": "MIT",
@@ -1567,7 +1460,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -1580,7 +1472,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/utils/-/utils-8.65.0.tgz",
       "integrity": "sha1-r+3ZdKDI3u71U7UJ31gAuv1hWnI=",
       "dev": true,
       "license": "MIT",
@@ -1604,7 +1495,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
       "integrity": "sha1-43BME8tKHCJFTBq/KP9HN+FQGMY=",
       "dev": true,
       "license": "MIT",
@@ -1622,7 +1512,6 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
       "integrity": "sha1-o1g0um5Gi8rWheyNBKU78M68wv8=",
       "dev": true,
       "license": "MIT",
@@ -1648,7 +1537,6 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/expect/-/expect-4.1.10.tgz",
       "integrity": "sha1-eZwG/ES7DPfieEE3tifFzBcyhdQ=",
       "dev": true,
       "license": "MIT",
@@ -1666,7 +1554,6 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/mocker/-/mocker-4.1.10.tgz",
       "integrity": "sha1-JBOYerTNf6HCthS0BMQHv2rR6tE=",
       "dev": true,
       "license": "MIT",
@@ -1693,7 +1580,6 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
       "integrity": "sha1-dVQucnOgjMEP1Nja1OPrHxbNlYw=",
       "dev": true,
       "license": "MIT",
@@ -1706,7 +1592,6 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/runner/-/runner-4.1.10.tgz",
       "integrity": "sha1-/r8KIakWhCFCLRlVNw5gb+q2A1U=",
       "dev": true,
       "license": "MIT",
@@ -1720,7 +1605,6 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/snapshot/-/snapshot-4.1.10.tgz",
       "integrity": "sha1-fj6f7H1NRyMuSTz9y9IXDeQ3HAQ=",
       "dev": true,
       "license": "MIT",
@@ -1736,7 +1620,6 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/spy/-/spy-4.1.10.tgz",
       "integrity": "sha1-XAv6l7Vrup43QDyXbbd2/2q1b2U=",
       "dev": true,
       "license": "MIT",
@@ -1746,7 +1629,6 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/utils/-/utils-4.1.10.tgz",
       "integrity": "sha1-/8cQVfGL/Msf0FhjZevCgkiS5AM=",
       "dev": true,
       "license": "MIT",
@@ -1761,7 +1643,6 @@
     },
     "node_modules/acorn": {
       "version": "8.17.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha1-F4WtuE+vjYrdEDabk4Jvwr0I8f4=",
       "dev": true,
       "license": "MIT",
@@ -1774,7 +1655,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
       "dev": true,
       "license": "MIT",
@@ -1784,7 +1664,6 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
       "dev": true,
       "license": "MIT",
@@ -1801,7 +1680,6 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha1-9kGhlrM1aQsQcL8AtudZP+wZC/c=",
       "dev": true,
       "license": "MIT",
@@ -1811,7 +1689,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
@@ -1821,7 +1698,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.44",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
       "integrity": "sha1-LgdGdeZAtnyzg1xUwRqi3ZEZwPg=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1834,7 +1710,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
       "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
       "dev": true,
       "license": "MIT",
@@ -1847,7 +1722,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.6.tgz",
       "integrity": "sha1-fPg6/NacVf3m+y3MUDn/D0ukJhA=",
       "dev": true,
       "funding": [
@@ -1881,7 +1755,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
       "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
@@ -1902,7 +1775,6 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chai/-/chai-6.2.2.tgz",
       "integrity": "sha1-rkG1LJrKh3NFBTYnF/MlX6zaNg4=",
       "dev": true,
       "license": "MIT",
@@ -1912,7 +1784,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
       "license": "MIT",
       "engines": {
@@ -1921,14 +1792,12 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "dev": true,
       "license": "MIT",
@@ -1943,14 +1812,12 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha1-Ff7DOyN/l6xdfJhtx32ic6jtC7U=",
       "license": "ISC",
       "dependencies": {
@@ -1962,7 +1829,6 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha1-OVsoM9+scVB/EqwvevI7+BneJOI=",
       "license": "ISC",
       "engines": {
@@ -1971,7 +1837,6 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha1-llisOKIUDVnTRhYPH2ww/aC9EvQ=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -1980,7 +1845,6 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha1-Af20a1i+sfVbELQq1wtuNE1esq4=",
       "license": "ISC",
       "engines": {
@@ -1989,7 +1853,6 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha1-PEeqWzLFs9+1bvP9Q0IHimMrQA0=",
       "license": "ISC",
       "dependencies": {
@@ -2001,7 +1864,6 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha1-It+TkDL7WnGuixgA1h3beFHEJSY=",
       "license": "ISC",
       "engines": {
@@ -2010,7 +1872,6 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha1-grOOjo/3CAdk+Nzsd71L45Nok5Y=",
       "license": "ISC",
       "dependencies": {
@@ -2026,7 +1887,6 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha1-oag5y9m6RfKGdMadf4Vbz5HfxqU=",
       "license": "ISC",
       "dependencies": {
@@ -2038,7 +1898,6 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha1-kxDbVumS48AXXh7zheVF5Iqbtcc=",
       "license": "ISC",
       "dependencies": {
@@ -2050,7 +1909,6 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha1-erUlelBB0R7LT+cKXH0WoZW7QIo=",
       "license": "ISC",
       "dependencies": {
@@ -2062,7 +1920,6 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha1-YoTSonCChbGrt+IB7aQ4CvNeY7A=",
       "license": "ISC",
       "engines": {
@@ -2071,7 +1928,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
@@ -2089,20 +1945,17 @@
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha1-E0/TJQjxniCPT7L42sDSYmqGeTQ=",
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
       "license": "Apache-2.0",
       "engines": {
@@ -2111,14 +1964,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.394",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
       "integrity": "sha1-G36vGrvqus7XzkAXBex8xIj9SSs=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
       "integrity": "sha1-QGu/HsIJcSZaMCVPCAMPzmqCB/4=",
       "license": "MIT",
       "dependencies": {
@@ -2131,14 +1982,12 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.49.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-toolkit/-/es-toolkit-1.49.0.tgz",
       "integrity": "sha1-k8WwMYZXkvwDy/W9IMEypPl2pSo=",
       "license": "MIT",
       "workspaces": [
@@ -2148,7 +1997,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -2158,7 +2006,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "dev": true,
       "license": "MIT",
@@ -2171,7 +2018,6 @@
     },
     "node_modules/eslint": {
       "version": "10.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint/-/eslint-10.7.0.tgz",
       "integrity": "sha1-zTuAIvOx47GDdg2Q38WOnTZEEGs=",
       "dev": true,
       "license": "MIT",
@@ -2230,7 +2076,6 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha1-5nQsrXXZcMCj8w19P6gKR4T1WSc=",
       "dev": true,
       "license": "MIT",
@@ -2250,7 +2095,6 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
       "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
       "dev": true,
       "license": "MIT",
@@ -2260,7 +2104,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha1-ud5qzi+rHP8k0uWNhbdMj86jmAI=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2279,7 +2122,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha1-njyUiWl4JNLUzjqK0SYo+R6fWb4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -2292,7 +2134,6 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/espree/-/espree-11.2.0.tgz",
       "integrity": "sha1-AdXkfcMyqrowWQCDYkVKjMNMyqU=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2310,7 +2151,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2323,7 +2163,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2336,7 +2175,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2346,7 +2184,6 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
       "dev": true,
       "license": "MIT",
@@ -2356,7 +2193,6 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2366,13 +2202,11 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha1-qG1mFwQzcS3egUcHrFK1JxzrH+s=",
       "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
       "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2382,28 +2216,24 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "license": "MIT",
       "engines": {
@@ -2420,7 +2250,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha1-d4e93PETG/+5JjbGlFe7wO3W2B8=",
       "dev": true,
       "license": "MIT",
@@ -2433,7 +2262,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "dev": true,
       "license": "MIT",
@@ -2450,7 +2278,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha1-Ds45/LFO4BL0sEEL0z3ZwfAREnw=",
       "dev": true,
       "license": "MIT",
@@ -2464,14 +2291,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha1-9cI8EH8PN96NvfJPE3IrO5jVJyY=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "license": "MIT",
       "optional": true,
@@ -2484,7 +2309,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true,
       "license": "MIT",
@@ -2494,7 +2318,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
       "dev": true,
       "license": "ISC",
@@ -2507,7 +2330,6 @@
     },
     "node_modules/globals": {
       "version": "17.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-17.7.0.tgz",
       "integrity": "sha1-VT1VCQtN3oIJ7C2kJYDW5+fYsQ0=",
       "dev": true,
       "license": "MIT",
@@ -2520,20 +2342,17 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "license": "ISC"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha1-au7BfRmDtOq/aXIfOqPrcFsX9IA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha1-W+Dkh7IJCIbGK9ihFyTNdm1fVNE=",
       "dev": true,
       "license": "MIT",
@@ -2543,7 +2362,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
       "dev": true,
       "license": "MIT",
@@ -2553,7 +2371,6 @@
     },
     "node_modules/immer": {
       "version": "11.1.15",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/immer/-/immer-11.1.15.tgz",
       "integrity": "sha1-GxeKkzhIat5ZOfp2z/Q/SkkAHrA=",
       "license": "MIT",
       "funding": {
@@ -2563,7 +2380,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "license": "MIT",
@@ -2573,7 +2389,6 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha1-ZoXyN1XkPFJOJR0py8lySOMGEAk=",
       "license": "ISC",
       "engines": {
@@ -2582,7 +2397,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
@@ -2592,7 +2406,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "license": "MIT",
@@ -2605,14 +2418,12 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
       "version": "2.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha1-l0Io8vTKK8IYhaF5e0X+po6VDGQ=",
       "license": "MIT",
       "bin": {
@@ -2621,14 +2432,12 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
@@ -2641,28 +2450,24 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "dev": true,
       "license": "MIT",
@@ -2675,7 +2480,6 @@
     },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jwt-decode/-/jwt-decode-4.0.0.tgz",
       "integrity": "sha1-InA1JCX9QTeFsvrxH251XFFRvUs=",
       "license": "MIT",
       "engines": {
@@ -2684,7 +2488,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
       "dev": true,
       "license": "MIT",
@@ -2694,7 +2497,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/levn/-/levn-0.4.1.tgz",
       "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "dev": true,
       "license": "MIT",
@@ -2708,7 +2510,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha1-uFqulkhtyxv0mnyFcSISc/Tx5Kk=",
       "license": "MPL-2.0",
       "dependencies": {
@@ -2737,7 +2538,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha1-8DOIURbf79nG9UeHUj41FLYeGWg=",
       "cpu": [
         "arm64"
@@ -2757,7 +2557,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha1-ULcYcbAcgZlYS2SeKSVH+up6+bU=",
       "cpu": [
         "arm64"
@@ -2777,7 +2576,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha1-NfPpczLRMLnKGB4RtWje1q68bV4=",
       "cpu": [
         "x64"
@@ -2797,7 +2595,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha1-l3enZHK2Ttb/lDQq1kx7r9eUpXU=",
       "cpu": [
         "x64"
@@ -2817,7 +2614,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha1-E65lLhq3O5E117faFy9mbEEK1T0=",
       "cpu": [
         "arm"
@@ -2837,7 +2633,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha1-QXhYeVqUWS9oASOhsfnaig4e8zU=",
       "cpu": [
         "arm64"
@@ -2857,7 +2652,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha1-a+NmkugQtxgECAL9gJYjz/5zITM=",
       "cpu": [
         "arm64"
@@ -2877,7 +2671,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha1-C3gDr06yHP043Tn+Kru1PH3QkfY=",
       "cpu": [
         "x64"
@@ -2897,7 +2690,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha1-iNyLqGXd3bGsXvBLDxYYBEGMFjs=",
       "cpu": [
         "x64"
@@ -2917,7 +2709,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha1-TzC6P6XpJfW3n5RejMDRdsOxqzg=",
       "cpu": [
         "arm64"
@@ -2937,7 +2728,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha1-FBqlYFZFBkkokCu0rwRfp9n0Igo=",
       "cpu": [
         "x64"
@@ -2957,7 +2747,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "dev": true,
       "license": "MIT",
@@ -2973,7 +2762,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "license": "ISC",
@@ -2983,7 +2771,6 @@
     },
     "node_modules/lucide-react": {
       "version": "1.26.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lucide-react/-/lucide-react-1.26.0.tgz",
       "integrity": "sha1-H5A8cuuNgOOx7bQEw6AlZC3FCqg=",
       "license": "ISC",
       "peerDependencies": {
@@ -2992,7 +2779,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE=",
       "license": "MIT",
       "dependencies": {
@@ -3001,7 +2787,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3017,14 +2802,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "funding": [
         {
@@ -3042,14 +2825,12 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
       "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
@@ -3059,7 +2840,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
       "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
@@ -3073,7 +2853,6 @@
     },
     "node_modules/oidc-client-ts": {
       "version": "3.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
       "integrity": "sha1-IiwUXTXo1lTqTh3uccxd3l4ckaI=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3085,7 +2864,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
       "dev": true,
       "license": "MIT",
@@ -3103,7 +2881,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "dev": true,
       "license": "MIT",
@@ -3119,7 +2896,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "dev": true,
       "license": "MIT",
@@ -3135,7 +2911,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true,
       "license": "MIT",
@@ -3145,7 +2920,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true,
       "license": "MIT",
@@ -3155,20 +2929,17 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha1-PsvsVUIWhbcKnahyss/z4cvtFxY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "license": "MIT",
       "engines": {
@@ -3180,7 +2951,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.21",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.21.tgz",
       "integrity": "sha1-R6d5vYMXM/9iDmCNIzsZXuHn1mw=",
       "funding": [
         {
@@ -3208,7 +2978,6 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "dev": true,
       "license": "MIT",
@@ -3218,7 +2987,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
       "dev": true,
       "license": "MIT",
@@ -3228,7 +2996,6 @@
     },
     "node_modules/react": {
       "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
@@ -3237,7 +3004,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
@@ -3249,14 +3015,12 @@
     },
     "node_modules/react-is": {
       "version": "19.2.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha1-V2aO6Gp4V0pUKwpTlFUhKywIbfI=",
       "license": "MIT",
       "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha1-owETu22VwKcV1U3aQwjUUPymzgk=",
       "license": "MIT",
       "dependencies": {
@@ -3279,7 +3043,6 @@
     },
     "node_modules/recharts": {
       "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
       "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
       "license": "MIT",
       "workspaces": [
@@ -3309,13 +3072,11 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/redux/-/redux-5.0.1.tgz",
       "integrity": "sha1-l/omiBzldGUAElWF1WQsd7bpRHs=",
       "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/redux-thunk/-/redux-thunk-3.1.0.tgz",
       "integrity": "sha1-lKpuBJd8MOFOiS6uhJeMGvYFj/M=",
       "license": "MIT",
       "peerDependencies": {
@@ -3324,13 +3085,11 @@
     },
     "node_modules/reselect": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/reselect/-/reselect-5.2.0.tgz",
       "integrity": "sha1-84DvdmQzLSbqBsHLoEvbvcqpVfE=",
       "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha1-M5quJQhENR/FW3TiZS0+vW+6OJ0=",
       "license": "MIT",
       "dependencies": {
@@ -3363,13 +3122,11 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha1-DE74LWfR5cHjWej8dtOofwRf5b0=",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-6.3.1.tgz",
       "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "dev": true,
       "license": "ISC",
@@ -3379,7 +3136,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "license": "MIT",
@@ -3392,7 +3148,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true,
       "license": "MIT",
@@ -3402,14 +3157,12 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "license": "BSD-3-Clause",
       "engines": {
@@ -3418,21 +3171,18 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
       "integrity": "sha1-iNgyQtHde8hHIj9z3PIQ3R8u4Rw=",
       "license": "MIT",
       "funding": {
@@ -3442,13 +3192,11 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha1-wAaGFhHCE8GHeJOrWyPaoWviu1U=",
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha1-XafJmSxGA4IhJnmFqyhCGoh58WA=",
       "license": "MIT",
       "engines": {
@@ -3461,20 +3209,17 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha1-RmgLeoc6DV0QAFmV65CnDXTWASc=",
       "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
@@ -3484,7 +3229,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "license": "MIT",
       "dependencies": {
@@ -3500,7 +3244,6 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha1-HYpiOJP5XPCi3bnl0RFQ4ZFAlCE=",
       "dev": true,
       "license": "MIT",
@@ -3510,7 +3253,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha1-Ss1KFV4ic0mQpe0f6el/ETvLN8E=",
       "dev": true,
       "license": "MIT",
@@ -3523,14 +3265,12 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "dev": true,
       "license": "MIT",
@@ -3543,7 +3283,6 @@
     },
     "node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha1-kCUdwAeRbpcnhsuU100VsYVXfSE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3557,7 +3296,6 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.65.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
       "integrity": "sha1-dUyVP9apo9NvpUAVvbqApusqSVc=",
       "dev": true,
       "license": "MIT",
@@ -3581,14 +3319,12 @@
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -3619,7 +3355,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3629,7 +3364,6 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha1-sXS/plyytSZzLZ8qwKQIAnh28y0=",
       "license": "MIT",
       "peerDependencies": {
@@ -3638,7 +3372,6 @@
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/victory-vendor/-/victory-vendor-37.3.6.tgz",
       "integrity": "sha1-QBrEsCmgs9M+DLqOih12XEhyVNo=",
       "license": "MIT AND ISC",
       "dependencies": {
@@ -3660,7 +3393,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.1.5.tgz",
       "integrity": "sha1-zP/OPuSHsYhiI7JOuye5FnSCfTA=",
       "license": "MIT",
       "dependencies": {
@@ -3737,7 +3469,6 @@
     },
     "node_modules/vitest": {
       "version": "4.1.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitest/-/vitest-4.1.10.tgz",
       "integrity": "sha1-fpKF7+JksRZwULejp/80eI4bevw=",
       "dev": true,
       "license": "MIT",
@@ -3827,7 +3558,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "license": "ISC",
@@ -3843,7 +3573,6 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
@@ -3860,7 +3589,6 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
       "dev": true,
       "license": "MIT",
@@ -3870,14 +3598,12 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true,
       "license": "MIT",
@@ -3890,7 +3616,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "dev": true,
       "license": "MIT",
@@ -3900,7 +3625,6 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha1-vGBeuknOD81ZjBJ/7hwja+PyKRg=",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary

- Add `omit-lockfile-registry-resolved=true` to the UI project's `.npmrc`.
- Regenerate the lockfile without changing its dependency graph, versions, integrity values, `lockfileVersion`, or other metadata.
- Remove registry `resolved` fields so Azure Artifacts feed URLs are not persisted.

## Validation

- `npx --yes npm@11.19.0 config get omit-lockfile-registry-resolved` returned `true`.
- A second `npx --yes npm@11.19.0 install --package-lock-only --ignore-scripts` made no changes.
- `ms-feed-2`, `ms-feed-12`, `ms-feed-17`, and `ms-feed-25` are absent from the lockfile.
- `npx --yes npm@11.19.0 ci --ignore-scripts` passed.
- `npx --yes npm@11.19.0 test` passed 46 tests.